### PR TITLE
DM-37235: Fix workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,7 @@ jobs:
   upload-for-branch:
     runs-on: ubuntu-latest
     needs: [build]
-    if: ${{ (github.event_name == 'pull_request') && startsWith(github.head_ref, "tickets/") }}
+    if: ${{ (github.event_name == 'pull_request') && startsWith(github.head_ref, 'tickets/') }}
 
     steps:
       - uses: actions/download-artifact@v3


### PR DESCRIPTION
The original workflow had a type (double quote instead of single quotes in a expression) that prevented it from running. This fixes that issue which we initially interpreted as the workflow not running because the workflow wasn't merged to main yet.