### PR TITLE
DM-37235: Fix upload for non-primary editions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,4 +139,5 @@ jobs:
           LTD_PASSWORD: ${{ secrets.LTD_PASSWORD }}
           LTD_USERNAME: ${{ secrets.LTD_USERNAME }}
         run: |
+          pip install ltd-conveyor
           ltd upload --dir _build/html/${{ matrix.rsp }} --product rsp --git-ref ${{ matrix.rsp }}


### PR DESCRIPTION
Needed to install ltd-conveyor since we're not using the lsst-sqre/ltd-upload action there. This fixes up #4 