### PR TITLE
DM-38053: Add a version switcher

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,18 +16,18 @@ repos:
           - yaml
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: v1.12.1
+    rev: 1.13.0
     hooks:
       - id: blacken-docs
         additional_dependencies: [black==22.10.0]

--- a/conf.py
+++ b/conf.py
@@ -59,10 +59,11 @@ html_theme_options["switcher"] = {  # noqa: F405
     ),
     "version_match": rsp_env.name,
 }
-html_theme_options["navbar_start"] = [  # noqa: F405
-    "navbar-logo",
+html_theme_options["navbar_center"] = [  # noqa: F405
     "version-switcher",
+    "navbar-nav",
 ]
+html_theme_options["navbar_align"] = "left"  # noqa: F405
 
 # Delete any objects that needn't be pickled with the Sphinx configuration
 del _config_template_loader

--- a/conf.py
+++ b/conf.py
@@ -50,6 +50,20 @@ if not rsp_env.nb_url:
 if not rsp_env.api_tap_url:
     exclude_patterns.append("guides/auth/using-topcat-outside-rsp.rst")
 
-# Delete any objects that needen't be picked with the Sphinx configuration
+# Add environment switcher
+html_theme_options["switcher"] = {  # noqa: F405
+    "json_url": (
+        "https://gist.githubusercontent.com/jonathansick/bbe902507790911d40173"
+        "f11a4a1a256/raw/345889140a6dff127a7a5c769e237449a086d721/"
+        "rsp-versions.json"
+    ),
+    "version_match": rsp_env.name,
+}
+html_theme_options["navbar_start"] = [  # noqa: F405
+    "navbar-logo",
+    "version-switcher",
+]
+
+# Delete any objects that needn't be pickled with the Sphinx configuration
 del _config_template_loader
 del _jinja_env

--- a/conf.py
+++ b/conf.py
@@ -65,6 +65,8 @@ html_theme_options["navbar_center"] = [  # noqa: F405
 ]
 html_theme_options["navbar_align"] = "left"  # noqa: F405
 
+html_static_path.append("docs/_static/versions.json")  # noqa: F405
+
 # Delete any objects that needn't be pickled with the Sphinx configuration
 del _config_template_loader
 del _jinja_env

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,0 +1,22 @@
+[
+  {
+    "name": "IDF",
+    "version": "idfprod",
+    "url": "https://rsp.lsst.io/"
+  },
+  {
+    "name": "IDF (integration)",
+    "version": "idfint",
+    "url": "https://rsp.lsst.io/v/idfint/"
+  },
+  {
+    "name": "Tucson Teststand",
+    "version": "tucson-teststand",
+    "url": "https://rsp.lsst.io/v/tucson-teststand/"
+  },
+  {
+    "name": "Summit",
+    "version": "summit",
+    "url": "https://rsp.lsst.io/v/summit/"
+  }
+]

--- a/src/rspdocs/phalanx/models.py
+++ b/src/rspdocs/phalanx/models.py
@@ -16,7 +16,7 @@ class PhalanxEnv(BaseModel):
     """A Pydantic model of a Phalanx environment."""
 
     name: str = Field(
-        descrption="The environment's name in Phalanx.", example="idfprod"
+        description="The environment's name in Phalanx.", example="idfprod"
     )
 
     title: str = Field(


### PR DESCRIPTION
This implements an environment selector based on the [PyData Sphinx Theme version dropdown widget](https://pydata-sphinx-theme.readthedocs.io/en/stable/user_guide/version-dropdown.html).

This version switcher currently uses data sourced from a temporary GitHub Gist that contains info about the main "public" RSP environments. A subsequent PR will switch to a versions.json hosted with the "main" version of the RSP docs itself.