### PR TITLE
DM-38053: Improve version switcher

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -51,9 +51,14 @@ if not rsp_env.api_tap_url:
     exclude_patterns.append("guides/auth/using-topcat-outside-rsp.rst")
 
 # Add environment switcher
+version = rsp_env.title  # noqa: F405
 html_theme_options["switcher"] = {  # noqa: F405
-    "json_url": "https://rsp.lsst.io/_static/versions.json",
-    "version_match": rsp_env.name,
+    "json_url": (
+        "https://gist.githubusercontent.com/jonathansick/bbe902507790911d40173"
+        "f11a4a1a256/raw/547a1ada8db54aac2540ca8291f5aa0b79923251/"
+        "rsp-versions.json"
+    ),
+    "version_match": rsp_env.title,
 }
 html_theme_options["navbar_center"] = [  # noqa: F405
     "version-switcher",

--- a/conf.py
+++ b/conf.py
@@ -52,11 +52,7 @@ if not rsp_env.api_tap_url:
 
 # Add environment switcher
 html_theme_options["switcher"] = {  # noqa: F405
-    "json_url": (
-        "https://gist.githubusercontent.com/jonathansick/bbe902507790911d40173"
-        "f11a4a1a256/raw/345889140a6dff127a7a5c769e237449a086d721/"
-        "rsp-versions.json"
-    ),
+    "json_url": "https://rsp.lsst.io/_static/versions.json",
     "version_match": rsp_env.name,
 }
 html_theme_options["navbar_center"] = [  # noqa: F405

--- a/docs/_static/versions.json
+++ b/docs/_static/versions.json
@@ -1,11 +1,16 @@
 [
   {
-    "name": "IDF",
+    "name": "data.lsst.cloud",
     "version": "idfprod",
     "url": "https://rsp.lsst.io/"
   },
   {
-    "name": "IDF (integration)",
+    "name": "Rubin Summit",
+    "version": "summit",
+    "url": "https://rsp.lsst.io/v/summit/"
+  },
+  {
+    "name": "Rubin IDF (Int)",
     "version": "idfint",
     "url": "https://rsp.lsst.io/v/idfint/"
   },
@@ -13,10 +18,5 @@
     "name": "Tucson Teststand",
     "version": "tucson-teststand",
     "url": "https://rsp.lsst.io/v/tucson-teststand/"
-  },
-  {
-    "name": "Summit",
-    "version": "summit",
-    "url": "https://rsp.lsst.io/v/summit/"
   }
 ]

--- a/tests/data/phalanxenvs.json
+++ b/tests/data/phalanxenvs.json
@@ -41,8 +41,8 @@
     },
     "idfprod": {
       "name": "idfprod",
-      "title": "Rubin IDF",
-      "title_full": "Rubin Interim Data Facility",
+      "title": "data.lsst.cloud",
+      "title_full": "data.lsst.cloud",
       "domain": "data.lsst.cloud",
       "squareone_url": "https://data.lsst.cloud/",
       "portal_url": "https://data.lsst.cloud/portal/app",


### PR DESCRIPTION
- Use data.lsst.cloud for the branding of the IDF Prod environment
- Fix the version matching so that the environment's displayed "title" is used, rather than the Phalanx name/LTD slug.
- Switch back to the Gist-hosted version file temporarily to avoid issues during development (this can be fixed with a dev-only build flag to change the behaviour).