### PR TITLE
DM-38053: Fix Edit on GitHub URL

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -66,6 +66,10 @@ html_theme_options["navbar_center"] = [  # noqa: F405
 ]
 html_theme_options["navbar_align"] = "left"  # noqa: F405
 
+# Update doc_path for the "Edit on GitHub" link. The DocumenteerGuide preset
+# doesn't work here because docs/ doesn't contain the Sphinx conf.py.
+html_context["doc_path"] = "docs"  # noqa: F405
+
 html_static_path.append("docs/_static/versions.json")  # noqa: F405
 
 # Delete any objects that needn't be pickled with the Sphinx configuration


### PR DESCRIPTION
The DocumeteerGuide preset for setting up the Edit on GitHub link here didn't work because the `docs/` directory doesn't contain conf.py (because it's a docs-first project, we wanted to keep `docs/` to just the documentation content itself).