### PR TITLE
Update rsp-versions to add USDF prod/dev and Base

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -57,9 +57,9 @@ if not rsp_env.times_square_url:
 version = rsp_env.title  # noqa: F405
 html_theme_options["switcher"] = {  # noqa: F405
     "json_url": (
-        "https://gist.githubusercontent.com/jonathansick/bbe902507790911d40173"
-        "f11a4a1a256/raw/547a1ada8db54aac2540ca8291f5aa0b79923251/"
-        "rsp-versions.json"
+        "https://gist.githubusercontent.com/jonathansick/bbe902507790911d4017"
+        "3f11a4a1a256/raw/50267ee4dc957bd817e93a12c79a1702377e6ae1"
+        "/rsp-versions.json"
     ),
     "version_match": rsp_env.title,
 }

--- a/docs/guides/getting-started/get-an-account.rst
+++ b/docs/guides/getting-started/get-an-account.rst
@@ -10,7 +10,7 @@ Getting an account on the RSP
    =====================================
 
    - Rubin data rights are required in order to hold an account in the Rubin Science Platform.
-     All scientists and students affiliated with an institution in the US and Chile have data rights, as well as the international scientists and students whose names appear on the `list of international data rights holders <https://lsst.org/scientists/international-drh-list>`__.
+     All scientists and students affiliated with an institution in the US and Chile have data rights, as well as the international scientists and students whose names appear on the `list of international data rights holders <https://www.lsst.org/scientists/international-drh-list>`__.
      For more information about data rights, please refer to the `Rubin Observatory Data Policy <https://docushare.lsst.org/docushare/dsweb/Get/RDO-013>`__.
      If you’re not sure if you have Rubin data rights, please contact Heather Shaughnessy at `sheather@slac.stanford.edu <mailto:sheather@slac.stanford.edu>`__.
 

--- a/documenteer.toml
+++ b/documenteer.toml
@@ -1,6 +1,6 @@
 [project]
 title = "Rubin Science Platform"
-copyright = "2018–2023 Association of Universities for Research in Astronomy, Inc. (AURA)"
+copyright = "2018–2024 Association of Universities for Research in Astronomy, Inc. (AURA)"
 base_url = "https://rsp.lsst.io"
 github_url = "https://github.com/lsst/rsp_lsst_io"
 version = "Current"


### PR DESCRIPTION
This is v7 of the rsp-versions.json file that powers the environments
drop-down menu. It adds items for usdfprod, usdfdev, and base.