### PR TITLE
Link to Times Square homepage

### DIFF
--- a/docs/guides/times-square/authoring/authoring-howto.rst
+++ b/docs/guides/times-square/authoring/authoring-howto.rst
@@ -2,7 +2,7 @@
 How to write a notebook for Times Square
 ########################################
 
-If you know how to create a Jupyter notebook, publishing a notebook to Times Square will be familiar.
+If you know how to create a Jupyter notebook, publishing a notebook to |times-square| will be familiar.
 This page outlines the basic steps for adding and authoring a notebook for Times Square, and links to further documentation.
 
 1. Setting up on the Science Platform Notebook Aspect
@@ -181,4 +181,4 @@ Whenever you push an update, Times Square will re-check and re-run the notebook.
 Therefore you can keep trying your notebook on Times Square until you're satisfied with the results.
 
 When you're ready to merge the pull request, click the "Merge pull request" button on the pull request page.
-At this point, the notebook will be available from the Times Square homepage.
+At this point, the notebook will be available from the |times-square| homepage.

--- a/docs/guides/times-square/index.rst
+++ b/docs/guides/times-square/index.rst
@@ -2,9 +2,17 @@
 Times Square
 ############
 
-Times Square lets you share Jupyter Notebooks as linkable web pages.
+|times-square| lets you share Jupyter Notebooks as linkable web pages.
 You can parameterize those notebooks for users to see results for different inputs.
 Times Square is great for sharing reports and analyses.
+
+.. jinja:: rsp
+
+   .. button-link:: {{ env.times_square_url }}
+      :outline:
+      :color: primary
+
+      Open Times Square :octicon:`link-external;1em`
 
 .. toctree::
    :titlesonly:

--- a/rst_epilog.rst.jinja
+++ b/rst_epilog.rst.jinja
@@ -22,7 +22,10 @@
 {% if env.api_tap_url %}
 .. |rsp-tap-url| replace:: `{{env.api_tap_url}} <{{env.api_tap_url}}>`__
 .. |rsp-tap-url-code| replace:: ``{{env.api_tap_url}}``
-{% endif%}
+{% endif %}
+{% if env.times_square_url %}
+.. |times-square| replace:: `Times Square <{{env.times_square_url}}>`__
+{% endif %}
 
 .. Templated link targets =====================================================
 

--- a/tests/data/phalanxenvs.json
+++ b/tests/data/phalanxenvs.json
@@ -91,7 +91,7 @@
       "api_tap_url": "https://usdf-rsp-dev.slac.stanford.edu/api/tap/",
       "gafaelfawr_tokens_url": "https://usdf-rsp-dev.slac.stanford.edu/auth/tokens/",
       "phalanx_docs_url": "https://phalanx.lsst.io/environments/usdfdev/index.html",
-      "times_square_url": "https://data-dev.lsst.cloud/times-square/"
+      "times_square_url": "https://usdf-rsp-dev.slac.stanford.edu/times-square/"
     },
     "usdfprod": {
       "name": "usdfprod",


### PR DESCRIPTION
|times-square| substitution is a link to Times Square. On the Times
Square guide homepage include a button to open Times Square.