### PR TITLE
DM-45913: Adjust linkcheck ignore for USDF and add periodic CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,21 +23,21 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.0
+        uses: pre-commit/action@v3.0.1
 
   testextensions:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
@@ -61,7 +61,7 @@ jobs:
           - "usdfprod"
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
@@ -69,7 +69,7 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           tox-envs: "sphinx-${{ matrix.rsp }},linkcheck-${{ matrix.rsp }}"
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.rsp }}
           path: _build/html/${{ matrix.rsp }}/
@@ -82,13 +82,13 @@ jobs:
     if: ${{ (github.event_name == 'pull_request') && startsWith(github.head_ref, 'tickets/') }}
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: idfprod
           path: _build/html/idfprod
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -119,13 +119,13 @@ jobs:
           - "usdfprod"
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: ${{ matrix.rsp }}
           path: _build/html/${{ matrix.rsp }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  PYTHON_VERSION: "3.12"
+
 "on":
   push:
     branches-ignore:
@@ -25,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Run pre-commit hooks
         uses: pre-commit/action@v3.0.0
@@ -39,7 +42,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
           tox-envs: "py,typing"
 
   build:
@@ -63,7 +66,7 @@ jobs:
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
           tox-envs: "sphinx-${{ matrix.rsp }},linkcheck-${{ matrix.rsp }}"
 
       - uses: actions/upload-artifact@v3
@@ -87,7 +90,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Upload to LSST the Docs
         uses: lsst-sqre/ltd-upload@v1
@@ -124,7 +127,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.10"
+          python-version: ${{ env.PYTHON_VERSION }}
 
       - name: Upload primary
         if: ${{ matrix.rsp == 'idfprod' }}

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -1,0 +1,92 @@
+# A regularly running workflow to validate that builds are working.
+
+name: Periodic CI
+
+env:
+  PYTHON_VERSION: "3.12"
+
+"on":
+  schedule:
+    - cron: "0 12 * * 1"
+  workflow_dispatch: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.1
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic job `lint` for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
+  testextensions:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          tox-envs: "py,typing"
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic job `testextensions` for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
+
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        rsp:
+          - "base"
+          - "idfdev"
+          - "idfint"
+          - "idfprod"
+          - "summit"
+          - "tucson-teststand"
+          - "usdfdev"
+          - "usdfprod"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run tox
+        uses: lsst-sqre/run-tox@v1
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+          tox-envs: "sphinx-${{ matrix.rsp }},linkcheck-${{ matrix.rsp }}"
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "Periodic job `build` for {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.6.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
@@ -8,7 +8,7 @@ repos:
       - id: check-toml
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.0-alpha.4
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types:
@@ -16,24 +16,24 @@ repos:
           - yaml
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         additional_dependencies: [toml]
 
   - repo: https://github.com/psf/black
-    rev: 23.1.0
+    rev: 24.8.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.13.0
+    rev: 1.18.0
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==22.10.0]
-        args: [-l, "79", -t, py38]
+        additional_dependencies: [black==24.8.0]
+        args: [-l, "79", -t, py312]
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.0.0
+    rev: 7.1.1
     hooks:
       - id: flake8

--- a/docs/contributing/style-guide.rst
+++ b/docs/contributing/style-guide.rst
@@ -42,7 +42,7 @@ DM's user documentation is written with soft wrapping, meaning that lines are as
 Never hard wrap to an arbitrary line length.
 Soft wrapping makes editing more approachable for more people (particularly those using the GitHub editor) and makes pull request line comments more useful.
 
-More specifically, use `semantic line formatting <http://rhodesmill.org/brandon/2012/one-sentence-per-line/>`__.
+More specifically, use `semantic line formatting <https://rhodesmill.org/brandon/2012/one-sentence-per-line/>`__.
 Generally this means that each sentence should be its own line in the text file.
 
 Titles and headings

--- a/docs/guides/notebooks/configuration/git-configuration.rst
+++ b/docs/guides/notebooks/configuration/git-configuration.rst
@@ -46,7 +46,7 @@ The next time Git asks for your credentials, it will store them in a ``~/.git-cr
 Git LFS for LSST
 ================
 
-The Notebook Aspect includes the `Git LFS <https://git-lfs.github.com>`_ client.
+The Notebook Aspect includes the `Git LFS <https://git-lfs.com>`_ client.
 
 Git LFS is preconfigured to allow anonymous access to LSST’s Git LFS-backed data repositories (such as https://github.com/lsst/afwdata).
 Members of the `lsst organization <https://github.com/lsst>`_ on GitHub can set up authenticated Git LFS access to push to LSST’s Git LFS repositories.

--- a/documenteer.toml
+++ b/documenteer.toml
@@ -22,4 +22,5 @@ ignore = [
     'https://summit-lsp.lsst.codes',
     'https://tucson-teststand.lsst.codes',
     'https://docushare.lsst.org',
+    'https://www.java.com/en/',  # Not accessible to the link checker
 ]

--- a/documenteer.toml
+++ b/documenteer.toml
@@ -21,6 +21,8 @@ ignore = [
     'https://data.lsst.cloud',
     'https://summit-lsp.lsst.codes',
     'https://tucson-teststand.lsst.codes',
+    'https://usdf-rsp-dev.slac.stanford.edu',
+    'https://usdf-rsp.slac.stanford.edu',
     'https://docushare.lsst.org',
     'https://www.java.com/en/',  # Not accessible to the link checker
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,4 +132,4 @@ strict_equality = true
 warn_redundant_casts = true
 warn_unreachable = true
 warn_unused_ignores = true
-# plugins =
+plugins = ["pydantic.mypy"]

--- a/src/rspdocs/phalanx/models.py
+++ b/src/rspdocs/phalanx/models.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from collections import UserDict
-from typing import Optional
 
 from pydantic import BaseModel, Field, HttpUrl
 
@@ -16,57 +15,57 @@ class PhalanxEnv(BaseModel):
     """A Pydantic model of a Phalanx environment."""
 
     name: str = Field(
-        description="The environment's name in Phalanx.", example="idfprod"
+        description="The environment's name in Phalanx.", examples=["idfprod"]
     )
 
     title: str = Field(
         description="The short title of the environment, usually an acronym.",
-        example="IDF",
+        examples=["IDF"],
     )
 
-    title_full: Optional[str] = Field(
+    title_full: str | None = Field(
         None,
         description="Full title, that expands acronyms",
-        example="Rubin Interim Data Facility",
+        examples=["Rubin Interim Data Facility"],
     )
 
     domain: str = Field(
         description="Domain name of the environment.",
-        example="data.lsst.cloud",
+        examples=["data.lsst.cloud"],
     )
 
     squareone_url: HttpUrl = Field(
         description="Root URL of the RSP homepage.",
-        example="https://data.lsst.cloud/",
+        examples=["https://data.lsst.cloud/"],
     )
 
-    portal_url: Optional[HttpUrl] = Field(
+    portal_url: HttpUrl | None = Field(
         None,
         description="Root URL for the portal.",
-        example="https://data.lsst.cloud/portal/app",
+        examples=["https://data.lsst.cloud/portal/app"],
     )
 
-    nb_url: Optional[HttpUrl] = Field(
+    nb_url: HttpUrl | None = Field(
         None,
         description="URL for the Nublado spawner page.",
-        example="https://data.lsst.cloud/nb/",
+        examples=["https://data.lsst.cloud/nb/"],
     )
 
-    api_url: Optional[HttpUrl] = Field(
+    api_url: HttpUrl | None = Field(
         None,
         description="Root URL for VO APIs.",
-        example="https://data.lsst.cloud/api/",
+        examples=["https://data.lsst.cloud/api/"],
     )
 
-    api_tap_url: Optional[HttpUrl] = Field(
+    api_tap_url: HttpUrl | None = Field(
         None,
         description="Root URL for the TAP service.",
-        example="https://data.lsst.cloud/api/tap/",
+        examples=["https://data.lsst.cloud/api/tap/"],
     )
 
     gafaelfawr_tokens_url: HttpUrl = Field(
         description="URL for the Gafaelfawr user tokens page.",
-        example="https://data.lsst.cloud/auth/tokens/",
+        examples=["https://data.lsst.cloud/auth/tokens/"],
     )
 
     phalanx_docs_url: HttpUrl = Field(
@@ -75,13 +74,13 @@ class PhalanxEnv(BaseModel):
             "Don't show this URL for public RSPs, but it may be appropriate "
             "for staff (internal) RSPs."
         ),
-        example="https://phalanx.lsst.io/environments/base/index.html",
+        examples=["https://phalanx.lsst.io/environments/base/index.html"],
     )
 
-    times_square_url: Optional[HttpUrl] = Field(
+    times_square_url: HttpUrl | None = Field(
         None,
         description="URL for root Times Square page (if deployed).",
-        example="https://data.lsst.cloud/times-square/",
+        examples=["https://data.lsst.cloud/times-square/"],
     )
 
     @property

--- a/src/rspdocs/phalanx/service.py
+++ b/src/rspdocs/phalanx/service.py
@@ -41,7 +41,7 @@ class PhalanxEnvService:
         cache_data = json.loads(cache_path.read_text())
         envs = EnvironmentDict()
         for env_name, env_data in cache_data["environments"].items():
-            envs[env_name] = PhalanxEnv.parse_obj(env_data)
+            envs[env_name] = PhalanxEnv.model_validate(env_data)
         return PhalanxEnvService(envs)
 
     @property

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    sphinx-{base,idfdev,idfint,idfprod,summit,tucson-teststand,usdfdev,usdfprod}
+    lint,sphinx-{base,idfdev,idfint,idfprod,summit,tucson-teststand,usdfdev,usdfprod}
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
- [x] Ignore links inside USDF, like in other environments. This allows us to ignore authenticated links inside the USDF RSP.
- [x] Ignore the java.com link, which has become an issue
- [x] Fixup links that have new permanent redirects
- [x] Add a periodically-running CI workflow to proactively detect link issues in the future.
- [x] Update the embedded `rspdocs` package to work with Pydantic 2.