### PR TITLE
DM-48421: Enable Times Square docs for usdfprod

### DIFF
--- a/documenteer.toml
+++ b/documenteer.toml
@@ -1,6 +1,6 @@
 [project]
 title = "Rubin Science Platform"
-copyright = "2018–2024 Association of Universities for Research in Astronomy, Inc. (AURA)"
+copyright = "2018–2025 Association of Universities for Research in Astronomy, Inc. (AURA)"
 base_url = "https://rsp.lsst.io"
 github_url = "https://github.com/lsst/rsp_lsst_io"
 version = "Current"

--- a/documenteer.toml
+++ b/documenteer.toml
@@ -25,4 +25,5 @@ ignore = [
     'https://usdf-rsp.slac.stanford.edu',
     'https://docushare.lsst.org',
     'https://www.java.com/en/',  # Not accessible to the link checker
+    'https://ui.adsabs.harvard.edu/abs/2022SPIE12189E..11J/abstract',
 ]

--- a/tests/data/phalanxenvs.json
+++ b/tests/data/phalanxenvs.json
@@ -104,7 +104,8 @@
       "api_url": "https://usdf-rsp.slac.stanford.edu/api/",
       "api_tap_url": "https://usdf-rsp.slac.stanford.edu/api/tap/",
       "gafaelfawr_tokens_url": "https://usdf-rsp.slac.stanford.edu/auth/tokens/",
-      "phalanx_docs_url": "https://phalanx.lsst.io/environments/usdfprod/index.html"
+      "phalanx_docs_url": "https://phalanx.lsst.io/environments/usdfprod/index.html",
+      "times_square_url": "https://usdf-rsp.slac.stanford.edu/times-square/"
     }
   }
 }


### PR DESCRIPTION
We're now deploying Times Square on usdfprod, so we'll add the user documentation for that by setting the url in phalanxenvs.json.