### PR TITLE
SP-1843: replace the term "delegate" in user-facing documentation

### DIFF
--- a/docs/guides/getting-started/get-an-account.rst
+++ b/docs/guides/getting-started/get-an-account.rst
@@ -109,7 +109,7 @@ Getting an account on the RSP
 
       This |rsp-at| is for internal Rubin Observatory engineering and testing.
 
-      If you are a DP0 delegate, switch to the main documentation at {{all_envs.primary.ltd_url_prefix}}.
+      If you are a science community member, switch to the main documentation at {{all_envs.primary.ltd_url_prefix}}.
 
    To get an account, request one from the RSP environment's administrators or your manager.
    {% endif %}

--- a/docs/guides/getting-started/linking-more-ids.rst
+++ b/docs/guides/getting-started/linking-more-ids.rst
@@ -41,6 +41,6 @@ Linking additional identities
 
       This |rsp-at| is for internal Rubin Observatory engineering and testing.
 
-      If you are a DP0 delegate, switch to the main documentation at {{all_envs.primary.ltd_url_prefix}}.
+      If you are a science community member, switch to the main documentation at {{all_envs.primary.ltd_url_prefix}}.
 
    {% endif %}


### PR DESCRIPTION
This pull request is part of a broader effort within Jira ticket SP-1843 to replace the term "delegate" in user-facing documentation.