### PR TITLE
DM-51289: Add Times Square docs for DAYOBS and dynamic date defaults, and scheduling

### DIFF
--- a/docs/guides/times-square/authoring/dynamic-date-defaults.rst
+++ b/docs/guides/times-square/authoring/dynamic-date-defaults.rst
@@ -1,0 +1,120 @@
+#######################################################
+Setting dynamic defaults for date and dayobs parameters
+#######################################################
+
+Times Square notebooks use date parameters to generate reports for specific dates or date ranges.
+With *dynamic defaults* for date parameters, you can set the default value of a date parameter to be relative to the current date so that users see the most relevant data when they view your notebook.
+
+Using a dynamic default
+=======================
+
+Parameters require a default value, which is set with the ``default`` field for that parameter.
+To make a date or dayobs parameter's default dynamic, replace that ``default`` field with a ``dynamic_default`` field:
+
+.. code-block:: diff
+   :caption: Example of a dynamic default for a date parameter
+
+   parameters:
+     start_date:
+        type: string
+        format: date
+   -  default: 2024-10-01
+   +  dynamic_default: "today"
+
+Dynamic defaults work with both date and dayobs parameters:
+
+.. code-block:: yaml
+   :caption: Example of a dynamic default for a dayobs parameter.
+
+   parameters:
+     start_dayobs:
+       type: string
+       format: dayobs
+       dynamic_default: "today"
+
+Format for the dynamic_default field
+====================================
+
+The ``dynamic_default`` field's syntax allows you to specify a date relative to the current date for a variety of use cases.
+
+Simple relative dates
+---------------------
+
+You can specify "today", "yesterday", or "tomorrow" to set the default to the current date, one day ago, or one day in the future, respectively:
+
+.. code-block:: yaml
+
+   dynamic_default: "today"     # Current date
+   dynamic_default: "yesterday" # One day ago
+   dynamic_default: "tomorrow"  # One day in the future
+
+Relative days with offsets
+--------------------------
+
+You can use a ``-<offset>d`` or ``+<offset>d`` syntax to specify a number of days in the past or future:
+
+.. code-block:: yaml
+
+   dynamic_default: "-2d" # Two days ago
+   dynamic_default: "+5d" # 5 days in the future
+
+
+Relative number of weeks
+------------------------
+
+You can use a ``-<offset>w`` or ``+<offset>w`` syntax to specify a number of weeks in the past or future:
+
+.. code-block:: yaml
+
+   dynamic_default: "-1w" # One week ago
+   dynamic_default: "+3w" # Three weeks in the future
+
+Relative number of months
+--------------------------
+
+You can use a ``-<offset>m`` or ``+<offset>m`` syntax to specify a number of months in the past or future:
+
+.. code-block:: yaml
+
+   dynamic_default: "-2m"  # Two months ago
+   dynamic_default: "+4m"  # Four months in the future
+
+Relative number of years
+--------------------------
+
+You can use a ``-<offset>y`` or ``+<offset>y`` syntax to specify a number of years in the past or future:
+
+.. code-block:: yaml
+
+   dynamic_default: "-1y"  # One year ago
+   dynamic_default: "+2y"  # Two years in the future
+
+Start or end of the current week, month, or year
+------------------------------------------------
+
+You can use the ``<unit>_start`` or ``<unit>_end`` syntax to set the default to the start or end of the current week, month, or year:
+
+.. code-block:: yaml
+
+   dynamic_default: "week_start"  # Start of the current week
+   dynamic_default: "week_end"    # End of the current week
+   dynamic_default: "month_start" # Start of the current month
+   dynamic_default: "month_end"   # End of the current month
+   dynamic_default: "year_start"  # Start of the current year
+   dynamic_default: "year_end"    # End of the current year
+
+.. note:: The start of a week is a Monday, and the end of a week is a Sunday.
+
+Start or end of the week, month, or year with offsets
+-----------------------------------------------------
+
+You can also specify an offset for the start or end of the week, month, or year:
+
+.. code-block:: yaml
+
+   dynamic_default: "-1week_start"   # Start of the previous week
+   dynamic_default: "+2week_end"     # End of the week two weeks in the future
+   dynamic_default: "-3month_start"  # Start of the month three months ago
+   dynamic_default: "+1month_end+1m" # End of the month, next month
+   dynamic_default: "-5year_start"   # Start of the year five years ago
+   dynamic_default: "+1year_end"     # End of next year

--- a/docs/guides/times-square/authoring/example-sidecar.yaml
+++ b/docs/guides/times-square/authoring/example-sidecar.yaml
@@ -9,8 +9,9 @@ tags:
 parameters:
   date:
     type: string
-    description: Night (YYYY-MM-DD)
-    default: "2024-01-08"
+    format: dayobs
+    description: Night (YYYYMMDD)
+    default: "20240108"
   other_parameter:
     type: integer
     description: Another parameter

--- a/docs/guides/times-square/authoring/index.rst
+++ b/docs/guides/times-square/authoring/index.rst
@@ -17,6 +17,7 @@ This section helps you understand how to write notebooks for Times Square, inclu
 
    authoring-howto
    dynamic-date-defaults
+   schedule-runs
 
 .. toctree::
    :titlesonly:

--- a/docs/guides/times-square/authoring/index.rst
+++ b/docs/guides/times-square/authoring/index.rst
@@ -16,6 +16,7 @@ This section helps you understand how to write notebooks for Times Square, inclu
    :caption: How to guides
 
    authoring-howto
+   dynamic-date-defaults
 
 .. toctree::
    :titlesonly:

--- a/docs/guides/times-square/authoring/parameter-types.rst
+++ b/docs/guides/times-square/authoring/parameter-types.rst
@@ -135,7 +135,7 @@ Besides specifying a time zone offset, you can also use the ``Z`` suffix to indi
 
    start_time = datetime.datetime.fromisoformat("2024-01-01T12:00:00Z")
 
-Note how Times Square automatically imports the :py:obj:`datetime` module for you in the parameters cell to parse the date into a :py:obj:`datetime.date` object.
+Note how Times Square automatically imports the :py:obj:`datetime` module for you in the parameters cell to parse the date into a :py:obj:`datetime.datetime` object.
 Replicate this pattern in the default parameters cell of your notebook.
 
 .. _ts-param-types-integer:
@@ -143,7 +143,7 @@ Replicate this pattern in the default parameters cell of your notebook.
 Integers
 ========
 
-For decimal numbers, use the ``integer`` type.
+For whole numbers, use the ``integer`` type.
 In your code, these values are Python ``int`` objects.
 
 .. code-block:: yaml
@@ -223,7 +223,6 @@ Booleans
 
 Boolean (true/false) values are supported with the ``boolean`` type.
 The string representation is based on JSON's ``true`` and ``false`` values.
-To convert the string into a Python boolean, you can compare the string:
 In your code, these values are Python bool (``True`` / ``False``) objects.
 
 .. code-block:: yaml

--- a/docs/guides/times-square/authoring/parameter-types.rst
+++ b/docs/guides/times-square/authoring/parameter-types.rst
@@ -57,6 +57,19 @@ Users enter dates in the format ``YYYY-MM-DD`` (ISO 8601) and your notebook rece
 Note how Times Square automatically imports the :py:obj:`datetime` module for you in the parameters cell to parse the date into a :py:obj:`datetime.date` object.
 Replicate this pattern in the default parameters cell of your notebook.
 
+Instead of a fixed default date, you can also set a *dynamic default* that is relative to the date the notebook is viewed:
+
+.. code-block:: yaml
+   :caption: Notebook YAML sidecar
+
+   parameters:
+     start_date:
+       type: string
+       format: date
+       dynamic_default: "today"
+
+See :doc:`dynamic-date-defaults` for more information about the syntax for ``dynamic_default``.
+
 .. _ts-param-types-dayobs:
 
 DAYOBS
@@ -81,6 +94,19 @@ DAYOBS is defined as the date in the UTC-12 timezone, and is represented as a st
    start_dayobs = "20240101"
 
 The format of the DAYOBS string is validated, but no processing is done in the parameters cell.
+
+Instead of a fixed default DAYOBS, you can also set a *dynamic default* that is relative to the date the notebook is viewed:
+
+.. code-block:: yaml
+   :caption: Notebook YAML sidecar
+
+   parameters:
+     start_dayobs:
+       type: string
+       format: dayobs
+       dynamic_default: "yesterday"
+
+See :doc:`dynamic-date-defaults` for more information about the syntax for ``dynamic_default``.
 
 .. _ts-param-types-datetime:
 

--- a/docs/guides/times-square/authoring/parameter-types.rst
+++ b/docs/guides/times-square/authoring/parameter-types.rst
@@ -57,6 +57,31 @@ Users enter dates in the format ``YYYY-MM-DD`` (ISO 8601) and your notebook rece
 Note how Times Square automatically imports the :py:obj:`datetime` module for you in the parameters cell to parse the date into a :py:obj:`datetime.date` object.
 Replicate this pattern in the default parameters cell of your notebook.
 
+.. _ts-param-types-dayobs:
+
+DAYOBS
+======
+
+Rubin Observatory uses DAYOBS to identify an observing night since the DAYOBS is consistent over the course of a night.
+DAYOBS is defined as the date in the UTC-12 timezone, and is represented as a string with eight digits: ``YYYYMMDD``.
+
+.. code-block:: yaml
+   :caption: Notebook YAML sidecar
+
+   parameters:
+     start_dayobs:
+       type: string
+       format: dayobs
+       description: A DAYOBS date
+       default: "20240101"
+
+.. code-block:: python
+   :caption: Notebook parameters cell
+
+   start_dayobs = "20240101"
+
+The format of the DAYOBS string is validated, but no processing is done in the parameters cell.
+
 .. _ts-param-types-datetime:
 
 Date and time

--- a/docs/guides/times-square/authoring/schedule-runs.rst
+++ b/docs/guides/times-square/authoring/schedule-runs.rst
@@ -108,6 +108,8 @@ For example, you can run a notebook daily on weekdays, but also at the end of th
        hour: 23
        minute: 55
 
+.. seealso:: The :doc:`sidecar metadata schema <sidecar-schema>` provides details on the :ref:`schedule <ts-sidecar-schema-schedule>` and :ref:`schedule_enabled <ts-sidecar-schema-schedule-enabled>` fields.
+
 Rules can skip events indicated by other rules
 ----------------------------------------------
 

--- a/docs/guides/times-square/authoring/schedule-runs.rst
+++ b/docs/guides/times-square/authoring/schedule-runs.rst
@@ -42,7 +42,7 @@ Other recipes for the ``schedule`` field include:
        minute: 15
 
 .. code-block:: yaml
-   :caption: Schedule a notebook to the last day of every month at 11:55 PM UTC:
+   :caption: Schedule a notebook to run on the last day of every month at 11:55 PM UTC:
 
    schedule:
      - freq: "monthly"
@@ -90,7 +90,7 @@ For example, you can run a notebook daily on weekdays, but also at the end of th
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run every weekday at 8:00 AM UTC and at the end of the month.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs every weekday at 8:00 AM UTC and at the end of the month."
    parameters: []
    schedule_enabled: true
@@ -115,14 +115,14 @@ Rules can skip events indicated by other rules
 
 Any schedule rule can have a ``exclude: true`` field that indicates any scheduled dates that match the rule should be skipped.
 The exclusion rules are processed after the inclusion rules, so you can think of this as "schedule these times, but not these times."
-This is useful to in combination with other rules that would otherwise run the notebook at unnecessary times.
+This is useful in combination with other rules that would otherwise run the notebook at unnecessary times.
 
 For example, if you want to run a notebook every day at 8:00 AM UTC, but skip weekends, you can use the following schedule:
 
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run every day at 8:00 AM UTC, but skips weekends.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs every day at 8:00 AM UTC, but skips weekends."
    parameters: []
    schedule_enabled: true
@@ -151,7 +151,7 @@ Times Square supports three basic types of schedule rules:
 
 - scheduling on a specific date (:ref:`example <ts-schedule-on-date>`)
 - scheduling a recurrence from a specific date (:ref:`example <ts-schedule-from-date>`)
-- complex rules based on days of the year, month, week, and hours and minutes in the day (:ref:`details <ts-complex-schedule-rules>`).
+- advanced rules based on days of the year, month, week, and hours and minutes in the day (:ref:`details <ts-advanced-schedule-rules>`).
 
 All of these schedule rules can be combined in the ``schedule`` array.
 The remainder of this guide describes each of these types of rules in detail.
@@ -166,7 +166,7 @@ To schedule a notebook to run on a single specific date and time, use schedule r
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run on a specific date.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs on a specific date."
    parameters: []
    schedule_enabled: true
@@ -184,7 +184,7 @@ For simple schedules, this can be the simplest type of schedule rule to set up a
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run every day starting from a specific date.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs every day starting from a specific date."
    parameters: []
    schedule_enabled: true
@@ -205,7 +205,7 @@ By default the interval is ``1``, but to run every other day, you can set the in
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run every other day starting from a specific date.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs every other day starting from a specific date."
    parameters: []
    schedule_enabled: true
@@ -214,13 +214,13 @@ By default the interval is ``1``, but to run every other day, you can set the in
        freq: "daily"
        interval: 2
 
-The remainder of this documentation describes how to set up more complex schedules based on days of the year, month, week, and hours and minutes in the day.
+The remainder of this documentation describes how to set up more advanced schedules based on days of the year, month, week, and hours and minutes in the day.
 The easiest way to understand these rules is through specific recipes.
 
-.. _ts-complex-schedule-rules:
+.. _ts-advanced-schedule-rules:
 
-Complex schedule rules
-======================
+Advanced schedule rules
+=======================
 
 Schedule a notebook to run every Monday at specific time
 --------------------------------------------------------
@@ -230,7 +230,7 @@ To schedule a notebook to run every Monday at a specific time, use the ``weekday
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run every Monday at 8:00 AM UTC.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs every Monday at 8:00 AM UTC."
    parameters: []
    schedule_enabled: true
@@ -249,7 +249,7 @@ Then for ``weekday`` field supply an object where ``day`` is ``monday``, and the
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run on the first Monday of every month at 8:00 AM UTC.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs on the first Monday of every month at 8:00 AM UTC."
    parameters: []
    schedule_enabled: true
@@ -273,7 +273,7 @@ This schedule is similar to the previous one, but now the index is ``-1`` to ind
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run on the last Friday of every month at 8:00 AM UTC.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs on the last Friday of every month at 8:00 AM UTC."
    parameters: []
    schedule_enabled: true
@@ -295,7 +295,7 @@ To schedule a notebook to run on the last day of every month, use the ``day_of_m
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run on the last day of every month at 8:00 AM UTC.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs on the last day of every month at 8:00 AM UTC."
    parameters: []
    schedule_enabled: true
@@ -313,7 +313,7 @@ To schedule a notebook to run on the first day of every month, use the ``day_of_
 .. code-block:: yaml
     :caption: Sidecar metadata YAML file that schedules a notebook to run on the first day of every month at 8:00 AM UTC.
 
-    tile: "My Notebook"
+    title: "My Notebook"
     description: "This notebook runs on the first day of every month at 8:00 AM UTC."
     parameters: []
     schedule_enabled: true
@@ -333,7 +333,7 @@ For example, to run the notebook both at 8:00 AM and at 5:00 PM UTC, you can use
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run at 8:00 AM and 5:00 PM UTC every day.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs at 8:00 AM and 5:00 PM UTC every day."
    parameters: []
    schedule_enabled: true
@@ -351,7 +351,7 @@ To schedule a notebook to run every hour, you can use the ``freq`` field with th
 .. code-block:: yaml
    :caption: Sidecar metadata YAML file that schedules a notebook to run every hour.
 
-   tile: "My Notebook"
+   title: "My Notebook"
    description: "This notebook runs every hour at 5 minutes past the hour."
    parameters: []
    schedule_enabled: true
@@ -367,8 +367,8 @@ To schedule a notebook to run every hour, you can use the ``freq`` field with th
 Troubleshooting and tips
 ========================
 
-Schedule rules can be complex, so here are some tips for troubleshooting and ensuring your schedules work as expected:
+Schedule rules can be advanced, so here are some tips for troubleshooting and ensuring your schedules work as expected:
 
 - **Times are in UTC**. The ``hour`` fields are in UTC, so make sure to convert your local time to UTC when setting the schedule. An alternative strategy is to set the ``start`` field in the schedule rule to a specific date and time in your local time zone, which will then be converted to UTC.
 - **Hour is in the 24-hour clock.** The ``hour`` field uses a 24-hour clock, so 8 AM is ``8`` and 5 PM is ``17``.
-- **Set freq to the interval the rule repeats over.** The ``freq`` field in schedule rules can be confusing. Is refers to the periodicity of the rule as a whole, rather than the rate that runs are scheduled. For example, a rule where weekday is ``[monday, tuesday, wednesday, thursday, friday]`` should have a ``freq`` of ``weekly`` rather than ``daily`` because that pattern as a whole repeats every week, not every day.
+- **Set freq to the interval the rule repeats over.** The ``freq`` field in schedule rules can be confusing. It refers to the periodicity of the rule as a whole, rather than the rate that runs are scheduled. For example, a rule where weekday is ``[monday, tuesday, wednesday, thursday, friday]`` should have a ``freq`` of ``weekly`` rather than ``daily`` because that pattern as a whole repeats every week, not every day.

--- a/docs/guides/times-square/authoring/schedule-runs.rst
+++ b/docs/guides/times-square/authoring/schedule-runs.rst
@@ -1,0 +1,372 @@
+##################################
+Scheduling automatic notebook runs
+##################################
+
+By default, Times Square runs a notebook when a user views it and the notebook hasn't already been computed with the requested parameters.
+For notebooks that are meant to update on a regular basis, especially those that use dates as parameters, you can schedule automatic runs of the notebook.
+Scheduled runs ensure that a notebook is always computed for a given date, and lets users see the page immediately without waiting for the notebook to run.
+
+Scheduled runs always use the parameter defaults defined in the notebook's sidecar metadata file.
+Scheduling works well with :doc:`dynamic defaults for date and dayobs parameters <dynamic-date-defaults>`, since those defaults are established at the time the notebook is run.
+If a scheduled run repeats the same parameters as a previous run, the results of the previous run are replaced with the new results.
+
+Scheduling is a powerful feature, and although there aren't currently restrictions on how often you can schedule a notebook, you should be careful not to schedule runs too frequently (such as several times an hour).
+For near-real-time updates, consider using dashboards in Chronograf or Grafana or even custom web applications instead of Times Square.
+
+Quick start
+===========
+
+To schedule a notebook to run automatically, add a ``schedule`` field to the notebook's :doc:`sidecar metadata file <sidecar-schema>`.
+Here are some common recipes for scheduling notebooks:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file with a daily run schedule:
+
+   title: "My Notebook"
+   description: "This notebook runs every day at 8:00 AM UTC."
+   parameters: []
+
+   schedule:
+     - freq: "daily"
+       hour: 8
+
+Other recipes for the ``schedule`` field include:
+
+.. code-block:: yaml
+   :caption: Schedule a notebook to run the first day of every month at 8:15 AM UTC:
+
+   schedule:
+     - freq: "monthly"
+       day_of_month: 1
+       hour: 8
+       minute: 15
+
+.. code-block:: yaml
+   :caption: Schedule a notebook to the last day of every month at 11:55 PM UTC:
+
+   schedule:
+     - freq: "monthly"
+       day_of_month: -1
+       hour: 23
+       minute: 55
+
+.. code-block:: yaml
+   :caption: Schedule a notebook to run every weekday at 8:00 AM UTC:
+
+    schedule:
+      - freq: "daily"
+         hour: 8
+         weekday:
+            - monday
+            - tuesday
+            - wednesday
+            - thursday
+            - friday
+
+How to create schedules is described below.
+
+Adding a schedule (in more detail)
+==================================
+
+Schedules are set in the notebook's :doc:`sidecar metadata file <sidecar-schema>` with two fields: ``schedule`` and ``schedule_enabled``.
+The latter is a boolean that enables or disables the schedule and can take values of ``true`` or ``false``.
+The former is an array of schedule *rules*.
+A basic schedule that runs a notebook every day at 8:00 AM UTC looks like this:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run every day at 8:00 AM UTC.
+
+   title: "My Notebook"
+   description: "This notebook runs every day at 8:00 AM UTC."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "daily"
+       hour: 8
+
+Because the schedule is an array of rules, you can combine multiple recipes.
+For example, you can run a notebook daily on weekdays, but also at the end of the month:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run every weekday at 8:00 AM UTC and at the end of the month.
+
+   tile: "My Notebook"
+   description: "This notebook runs every weekday at 8:00 AM UTC and at the end of the month."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "daily"
+       hour: 8
+       weekday:
+         - monday
+         - tuesday
+         - wednesday
+         - thursday
+         - friday
+     - freq: "monthly"
+       day_of_month: -1
+       hour: 23
+       minute: 55
+
+Rules can skip events indicated by other rules
+----------------------------------------------
+
+Any schedule rule can have a ``exclude: true`` field that indicates any scheduled dates that match the rule should be skipped.
+The exclusion rules are processed after the inclusion rules, so you can think of this as "schedule these times, but not these times."
+This is useful to in combination with other rules that would otherwise run the notebook at unnecessary times.
+
+For example, if you want to run a notebook every day at 8:00 AM UTC, but skip weekends, you can use the following schedule:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run every day at 8:00 AM UTC, but skips weekends.
+
+   tile: "My Notebook"
+   description: "This notebook runs every day at 8:00 AM UTC, but skips weekends."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "daily"
+       hour: 8
+     - freq: "daily"
+       weekday:
+         - saturday
+         - sunday
+       hour: 8
+       exclude: true
+
+Schedules are generally in the UTC time zone
+--------------------------------------------
+
+Times Square schedules are generally in the UTC time zone.
+When you specify ``hour``, that hour is in UTC.
+
+Schedules that :ref:`start from a specific date <ts-schedule-on-date>` can set their timezone in the reference ``start`` field if you want to use a different time zone without having to convert the time to UTC.
+
+Three types of schedule rules
+-----------------------------
+
+Times Square supports three basic types of schedule rules:
+
+- scheduling on a specific date (:ref:`example <ts-schedule-on-date>`)
+- scheduling a recurrence from a specific date (:ref:`example <ts-schedule-from-date>`)
+- complex rules based on days of the year, month, week, and hours and minutes in the day (:ref:`details <ts-complex-schedule-rules>`).
+
+All of these schedule rules can be combined in the ``schedule`` array.
+The remainder of this guide describes each of these types of rules in detail.
+
+.. _ts-schedule-on-date:
+
+Scheduling on a specific date
+=============================
+
+To schedule a notebook to run on a single specific date and time, use schedule rule with a ``date`` field that has an ISO 8601 date string:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run on a specific date.
+
+   tile: "My Notebook"
+   description: "This notebook runs on a specific date."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - date: "2024-10-10T08:00:00Z"
+
+.. _ts-schedule-from-date:
+
+Schedule a recurrence from a specific date
+==========================================
+
+To schedule a notebook from a given start date that repeats at a given frequency, use a schedule rule with a ``start`` field that takes an ISO 8601 date string and a ``freq`` field that indicates the frequency of the recurrence.
+For simple schedules, this can be the simplest type of schedule rule to set up and understand.
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run every day starting from a specific date.
+
+   tile: "My Notebook"
+   description: "This notebook runs every day starting from a specific date."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - start: "2024-10-10T08:00:00Z"
+       freq: "daily"
+
+The ``freq`` field can take the following values:
+
+- ``daily``: runs every day at the specified time.
+- ``weekly``: runs every week on the specified day of the week at the specified time.
+- ``monthly``: runs every month on the specified day of the month at the specified time.
+- ``yearly``: runs every year on the specified day of the year at the specified time.
+
+You can also specify an ``interval`` field.
+By default the interval is ``1``, but to run every other day, you can set the interval to ``2`` for example.
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run every other day starting from a specific date.
+
+   tile: "My Notebook"
+   description: "This notebook runs every other day starting from a specific date."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - start: "2024-10-10T08:00:00Z"
+       freq: "daily"
+       interval: 2
+
+The remainder of this documentation describes how to set up more complex schedules based on days of the year, month, week, and hours and minutes in the day.
+The easiest way to understand these rules is through specific recipes.
+
+.. _ts-complex-schedule-rules:
+
+Complex schedule rules
+======================
+
+Schedule a notebook to run every Monday at specific time
+--------------------------------------------------------
+
+To schedule a notebook to run every Monday at a specific time, use the ``weekday`` field with the value ``monday`` and specify the hour and minute in UTC:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run every Monday at 8:00 AM UTC.
+
+   tile: "My Notebook"
+   description: "This notebook runs every Monday at 8:00 AM UTC."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "weekly"
+       weekday: monday
+       hour: 8
+       minute: 0
+
+Schedule a notebook to run on the first Monday of every month
+-------------------------------------------------------------
+
+To schedule a notebook to run on the first Monday of every month, set the ``freq`` to ``monthly``.
+Then for ``weekday`` field supply an object where ``day`` is ``monday``, and the ``index`` is ``1``:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run on the first Monday of every month at 8:00 AM UTC.
+
+   tile: "My Notebook"
+   description: "This notebook runs on the first Monday of every month at 8:00 AM UTC."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "monthly"
+       weekday:
+         - day: monday
+           index: 1
+       hour: 8
+       minute: 0
+
+The ``index`` field takes its meaning from the ``freq`` field.
+With a monthly frequency, ``index`` refers to that monthly interval so ``1`` means the first Monday in each month.
+If ``freq`` is ``yearly``, then ``index`` refers to the yearly interval, so ``1`` means the first Monday in the year.
+
+Schedule a notebook to run on the last Friday of every month
+------------------------------------------------------------
+
+This schedule is similar to the previous one, but now the index is ``-1`` to indicate the last occurrence of the day in the month:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run on the last Friday of every month at 8:00 AM UTC.
+
+   tile: "My Notebook"
+   description: "This notebook runs on the last Friday of every month at 8:00 AM UTC."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "monthly"
+       weekday:
+         - day: friday
+           index: -1
+       hour: 8
+       minute: 0
+
+Use ``-2`` to indicate the second-to-last occurrence of the day in the interval, and so on.
+
+Schedule a notebook to run on the last day of every month
+---------------------------------------------------------
+
+To schedule a notebook to run on the last day of every month, use the ``day_of_month`` field with the value ``-1``:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run on the last day of every month at 8:00 AM UTC.
+
+   tile: "My Notebook"
+   description: "This notebook runs on the last day of every month at 8:00 AM UTC."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "monthly"
+       day_of_month: -1
+       hour: 8
+       minute: 0
+
+Schedule a notebook to run on the first day of every month
+----------------------------------------------------------
+
+To schedule a notebook to run on the first day of every month, use the ``day_of_month`` field with the value ``1``:
+
+.. code-block:: yaml
+    :caption: Sidecar metadata YAML file that schedules a notebook to run on the first day of every month at 8:00 AM UTC.
+
+    tile: "My Notebook"
+    description: "This notebook runs on the first day of every month at 8:00 AM UTC."
+    parameters: []
+    schedule_enabled: true
+    schedule:
+      - freq: "monthly"
+         day_of_month: 1
+         hour: 8
+         minute: 0
+
+Schedule a notebook to run multiple times a day
+-----------------------------------------------
+
+Most examples use the ``hour`` and ``minute`` fields to specify a single time of day (in UTC) to run the notebook.
+You can also provide a list of hours and minutes to run the notebook multiple times a day.
+For example, to run the notebook both at 8:00 AM and at 5:00 PM UTC, you can use the following schedule:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run at 8:00 AM and 5:00 PM UTC every day.
+
+   tile: "My Notebook"
+   description: "This notebook runs at 8:00 AM and 5:00 PM UTC every day."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "daily"
+       hour:
+         - 8
+         - 17
+
+Schedule a notebook to run every hour
+-------------------------------------
+
+To schedule a notebook to run every hour, you can use the ``freq`` field with the value ``hourly``:
+
+.. code-block:: yaml
+   :caption: Sidecar metadata YAML file that schedules a notebook to run every hour.
+
+   tile: "My Notebook"
+   description: "This notebook runs every hour at 5 minutes past the hour."
+   parameters: []
+   schedule_enabled: true
+   schedule:
+     - freq: "hourly"
+       minute: 5
+       hour: null
+
+.. tip::
+
+   The ``hour`` field can be set to ``null`` to indicate that the notebook should run every hour at the specified minute rather than the default hour (which is 0).
+
+Troubleshooting and tips
+========================
+
+Schedule rules can be complex, so here are some tips for troubleshooting and ensuring your schedules work as expected:
+
+- **Times are in UTC**. The ``hour`` fields are in UTC, so make sure to convert your local time to UTC when setting the schedule. An alternative strategy is to set the ``start`` field in the schedule rule to a specific date and time in your local time zone, which will then be converted to UTC.
+- **Hour is in the 24-hour clock.** The ``hour`` field uses a 24-hour clock, so 8 AM is ``8`` and 5 PM is ``17``.
+- **Set freq to the interval the rule repeats over.** The ``freq`` field in schedule rules can be confusing. Is refers to the periodicity of the rule as a whole, rather than the rate that runs are scheduled. For example, a rule where weekday is ``[monday, tuesday, wednesday, thursday, friday]`` should have a ``freq`` of ``weekly`` rather than ``daily`` because that pattern as a whole repeats every week, not every day.

--- a/docs/guides/times-square/authoring/sidecar-schema.rst
+++ b/docs/guides/times-square/authoring/sidecar-schema.rst
@@ -69,6 +69,7 @@ For example:
        default: 2024-02-01
      end_date:
        type: string
+       format: date
        default: 2024-02-29
 
 .. code-block:: yaml
@@ -93,7 +94,11 @@ Each parameter is an object with the following fields:
   - ``number`` (floating-point number)
   - ``boolean``
 
-- ``format`` (*string*, optional) is a format string that describes the expected format of the parameter value. Specify ``date`` for date parameters and ``date-time`` for date-time parameters.
+- ``format`` (*string*, optional) is a format string that describes the expected format of the parameter value:
+
+  - ``date`` for date parameters (e.g., ``2024-10-10``)
+  - ``dayobs`` for Rubin DAYOBS dates (e.g., ``20241010``), defined as the date in UTC-12.
+  - ``date-time`` for date-time parameters (e.g., ``2024-10-10T04:00Z``).
 
 - ``default`` (*string*, required) is the default value of the parameter.
 

--- a/docs/guides/times-square/authoring/sidecar-schema.rst
+++ b/docs/guides/times-square/authoring/sidecar-schema.rst
@@ -111,3 +111,91 @@ Each parameter is an object with the following fields:
 - ``maximum`` (*integer* or *number*, optional) is the maximum value of the parameter, for numeric parameters.
 
 For more information about parameters, see :doc:`parameter-types`.
+
+schedule
+--------
+
+(*array of objects*, optional) A notebook can have multiple schedule rules that define when the notebook should be executed automatically.
+Each schedule rule is an object that can take one of three forms:
+
+Fixed date schedule
+^^^^^^^^^^^^^^^^^^^
+
+A schedule rule for a fixed date and time:
+
+.. code-block:: yaml
+   :caption: Fixed date schedule example
+
+   schedule:
+     - date: 2024-12-25T09:00:00Z
+       exclude: false
+
+Fields:
+
+- ``date`` (*string*, required) A fixed date-time to include (or exclude) from the schedule. The date-time should be in ISO 8601 format (e.g., ``2024-12-25T09:00:00Z``).
+- ``exclude`` (*boolean*, optional) Set to ``true`` to exclude this date from the schedule. Defaults to ``false``.
+
+Recurring schedule from a start date
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A schedule rule that repeats from a specific starting date:
+
+.. code-block:: yaml
+   :caption: Recurring schedule from start date example
+
+   schedule:
+     - start: 2024-01-01T09:00:00Z
+       freq: monthly
+       interval: 2
+       count: 6
+       exclude: false
+
+Fields:
+
+- ``start`` (*string*, required) The date-time when the repeating rule starts. Should be in ISO 8601 format.
+- ``freq`` (*string*, required) Frequency of recurrence. One of: ``yearly``, ``monthly``, ``weekly``, ``daily``, ``hourly``, ``minutely``.
+- ``interval`` (*integer*, optional) The interval between each iteration. For example, if ``freq`` is ``monthly``, an interval of ``2`` means every two months. Defaults to ``1``.
+- ``end`` (*string*, optional) The date-time when this rule ends. The last recurrence is less than or equal to this date. Cannot be used with ``count``.
+- ``count`` (*integer*, optional) The number of occurrences of this recurring rule. Cannot be used with ``end``.
+- ``exclude`` (*boolean*, optional) Set to ``true`` to exclude these events from the schedule. Defaults to ``false``.
+
+Complex recurring schedule
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A schedule rule with advanced recurrence patterns (based on RFC 5545 iCalendar standard):
+
+.. code-block:: yaml
+   :caption: Complex recurring schedule example
+
+   schedule:
+     - freq: monthly
+       weekday:
+         - day: friday
+           index: 1  # First Friday of the month
+       hour: [9]
+       minute: [0]
+       exclude: false
+
+Fields:
+
+- ``freq`` (*string*, required) Frequency of recurrence. One of: ``yearly``, ``monthly``, ``weekly``, ``daily``, ``hourly``, ``minutely``.
+- ``week_start`` (*string*, optional) The week start day for weekly frequencies. One of: ``sunday``, ``monday``, ``tuesday``, ``wednesday``, ``thursday``, ``friday``, ``saturday``. Defaults to ``monday``.
+- ``set_position`` (*integer*, or *array of integers*, optional) Specifies occurrence numbers within the recurrence frequency. For example, with monthly frequency and ``weekday`` of Friday, a value of ``1`` specifies the first Friday of the month, ``-1`` specifies the last Friday.
+- ``month`` (*integer*, or *array of integers*, optional) The months (1-12) when recurrence happens. Use negative integers to specify from end of year.
+- ``day_of_month`` (*integer*, or *array of integers*, optional) The days of the month (1-31) when recurrence happens. Use negative integers to specify from end of month.
+- ``day_of_year`` (*integer*, or *array of integers*, optional) The days of the year (1-366) when recurrence happens. Use negative integers to specify from end of year.
+- ``week`` (*integer*, or *array of integers*, optional) The weeks of the year (1-52) when recurrence happens. Use negative integers to specify from end of year.
+- ``weekday`` (*string*, *array of strings*, *object*, or *array of objects*, optional) The days of the week when recurrence happens. As a string this is the day of the week. Use the object form to also include an index in the frequency period. Each object has:
+
+  - ``day`` (*string*, required) The day of the week: ``sunday``, ``monday``, ``tuesday``, ``wednesday``, ``thursday``, ``friday``, ``saturday``.
+  - ``index`` (*integer*, optional) The index of the weekday. For monthly frequency, ``1`` means the first occurrence of that weekday in the month, ``-1`` means the last.
+
+- ``hour`` (*integer*, or *array of integers*, optional) The hours of the day (0-23) when recurrence happens. Defaults to ``[0]``.
+- ``minute`` (*integer*, or *array of integers*, optional) The minutes of the hour (0-59) when recurrence happens. Defaults to ``[0]``.
+- ``second`` (*integer*, or *integer*, optional) The second of the minute (0-59) when recurrence happens. Defaults to ``0``.
+- ``exclude`` (*boolean*, optional) Set to ``true`` to exclude these events from the schedule. Defaults to ``false``.
+
+schedule_enabled
+----------------
+
+(*boolean*, optional) If set to ``false``, the schedule is disabled and no automatic notebook runs will occur.

--- a/docs/guides/times-square/authoring/sidecar-schema.rst
+++ b/docs/guides/times-square/authoring/sidecar-schema.rst
@@ -100,7 +100,9 @@ Each parameter is an object with the following fields:
   - ``dayobs`` for Rubin DAYOBS dates (e.g., ``20241010``), defined as the date in UTC-12.
   - ``date-time`` for date-time parameters (e.g., ``2024-10-10T04:00Z``).
 
-- ``default`` (*string*, required) is the default value of the parameter.
+- ``default`` (*string*, required) is the default value of the parameter. The default must be a valid value for the parameter.
+
+  For ``date`` and ``dayobs`` format parameters, the ``default`` field can be replaced with a ``dynamic_default`` field to set a default relative to the current date. See :doc:`dynamic-date-defaults` for more information.
 
 - ``description`` (*Markdown string*) is the description of the parameter as it appears in the Times Square UI.
 

--- a/docs/guides/times-square/authoring/sidecar-schema.rst
+++ b/docs/guides/times-square/authoring/sidecar-schema.rst
@@ -18,6 +18,8 @@ Example file
 YAML field reference
 ====================
 
+.. _ts-sidecar-schema-title:
+
 title
 -----
 
@@ -27,10 +29,14 @@ It should be fairly short because it is displayed in a narrow column.
 
 The name can be contextual with the notebook's directory path (and repository name and even GitHub organization name).
 
+.. _ts-sidecar-schema-description:
+
 description
 -----------
 
 (*Markdown string*, optional) This is the description of the notebook as it appears in the Times Square UI. The description can be formatted as Markdown to include links to other URLs.
+
+.. _ts-sidecar-schema-authors:
 
 authors
 -------
@@ -42,10 +48,14 @@ authors
 - ``email`` (*string*, optional) The email address of the author.
 - ``affiliation_name`` (*string*, optional) The name of the author's affiliation.
 
+.. _ts-sidecar-schema-tags:
+
 tags
 ----
 
 (*array of strings*, optional) A notebook can have multiple tags. Each tag is a string.
+
+.. _ts-sidecar-schema-parameters:
 
 parameters
 ----------
@@ -111,6 +121,8 @@ Each parameter is an object with the following fields:
 - ``maximum`` (*integer* or *number*, optional) is the maximum value of the parameter, for numeric parameters.
 
 For more information about parameters, see :doc:`parameter-types`.
+
+.. _ts-sidecar-schema-schedule:
 
 schedule
 --------
@@ -194,6 +206,8 @@ Fields:
 - ``minute`` (*integer*, or *array of integers*, optional) The minutes of the hour (0-59) when recurrence happens. Defaults to ``[0]``.
 - ``second`` (*integer*, or *integer*, optional) The second of the minute (0-59) when recurrence happens. Defaults to ``0``.
 - ``exclude`` (*boolean*, optional) Set to ``true`` to exclude these events from the schedule. Defaults to ``false``.
+
+.. _ts-sidecar-schema-schedule-enabled:
 
 schedule_enabled
 ----------------

--- a/docs/guides/times-square/authoring/sidecar-schema.rst
+++ b/docs/guides/times-square/authoring/sidecar-schema.rst
@@ -171,13 +171,13 @@ Fields:
 - ``count`` (*integer*, optional) The number of occurrences of this recurring rule. Cannot be used with ``end``.
 - ``exclude`` (*boolean*, optional) Set to ``true`` to exclude these events from the schedule. Defaults to ``false``.
 
-Complex recurring schedule
-^^^^^^^^^^^^^^^^^^^^^^^^^^
+Advanced recurring schedule
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 A schedule rule with advanced recurrence patterns (based on RFC 5545 iCalendar standard):
 
 .. code-block:: yaml
-   :caption: Complex recurring schedule example
+   :caption: Advanced recurring schedule example
 
    schedule:
      - freq: monthly
@@ -192,19 +192,19 @@ Fields:
 
 - ``freq`` (*string*, required) Frequency of recurrence. One of: ``yearly``, ``monthly``, ``weekly``, ``daily``, ``hourly``, ``minutely``.
 - ``week_start`` (*string*, optional) The week start day for weekly frequencies. One of: ``sunday``, ``monday``, ``tuesday``, ``wednesday``, ``thursday``, ``friday``, ``saturday``. Defaults to ``monday``.
-- ``set_position`` (*integer*, or *array of integers*, optional) Specifies occurrence numbers within the recurrence frequency. For example, with monthly frequency and ``weekday`` of Friday, a value of ``1`` specifies the first Friday of the month, ``-1`` specifies the last Friday.
-- ``month`` (*integer*, or *array of integers*, optional) The months (1-12) when recurrence happens. Use negative integers to specify from end of year.
-- ``day_of_month`` (*integer*, or *array of integers*, optional) The days of the month (1-31) when recurrence happens. Use negative integers to specify from end of month.
-- ``day_of_year`` (*integer*, or *array of integers*, optional) The days of the year (1-366) when recurrence happens. Use negative integers to specify from end of year.
-- ``week`` (*integer*, or *array of integers*, optional) The weeks of the year (1-52) when recurrence happens. Use negative integers to specify from end of year.
+- ``set_position`` (*integer* or *array of integers*, optional) Specifies occurrence numbers within the recurrence frequency. For example, with monthly frequency and ``weekday`` of Friday, a value of ``1`` specifies the first Friday of the month, ``-1`` specifies the last Friday.
+- ``month`` (*integer* or *array of integers*, optional) The months (1-12) when recurrence happens. Use negative integers to specify from end of year.
+- ``day_of_month`` (*integer* or *array of integers*, optional) The days of the month (1-31) when recurrence happens. Use negative integers to specify from end of month.
+- ``day_of_year`` (*integer* or *array of integers*, optional) The days of the year (1-366) when recurrence happens. Use negative integers to specify from end of year.
+- ``week`` (*integer* or *array of integers*, optional) The weeks of the year (1-52) when recurrence happens. Use negative integers to specify from end of year.
 - ``weekday`` (*string*, *array of strings*, *object*, or *array of objects*, optional) The days of the week when recurrence happens. As a string this is the day of the week. Use the object form to also include an index in the frequency period. Each object has:
 
   - ``day`` (*string*, required) The day of the week: ``sunday``, ``monday``, ``tuesday``, ``wednesday``, ``thursday``, ``friday``, ``saturday``.
   - ``index`` (*integer*, optional) The index of the weekday. For monthly frequency, ``1`` means the first occurrence of that weekday in the month, ``-1`` means the last.
 
-- ``hour`` (*integer*, or *array of integers*, optional) The hours of the day (0-23) when recurrence happens. Defaults to ``[0]``.
-- ``minute`` (*integer*, or *array of integers*, optional) The minutes of the hour (0-59) when recurrence happens. Defaults to ``[0]``.
-- ``second`` (*integer*, or *integer*, optional) The second of the minute (0-59) when recurrence happens. Defaults to ``0``.
+- ``hour`` (*integer* or *array of integers*, optional) The hours of the day (0-23) when recurrence happens. Defaults to ``[0]``.
+- ``minute`` (*integer* or *array of integers*, optional) The minutes of the hour (0-59) when recurrence happens. Defaults to ``[0]``.
+- ``second`` (*integer*, optional) The second of the minute (0-59) when recurrence happens. Defaults to ``0``.
 - ``exclude`` (*boolean*, optional) Set to ``true`` to exclude these events from the schedule. Defaults to ``false``.
 
 .. _ts-sidecar-schema-schedule-enabled:


### PR DESCRIPTION
Add documentation for new Times Square features:

- dayobs date parameters
- dynamic defaults for dates
- scheduling automatic runs of notebooks