### PR TITLE
DM-51345: Document dayobs-date and revised dayobs parameters

### DIFF
--- a/docs/guides/times-square/authoring/dynamic-date-defaults.rst
+++ b/docs/guides/times-square/authoring/dynamic-date-defaults.rst
@@ -9,7 +9,7 @@ Using a dynamic default
 =======================
 
 Parameters require a default value, which is set with the ``default`` field for that parameter.
-To make a date or dayobs parameter's default dynamic, replace that ``default`` field with a ``dynamic_default`` field:
+To make a date, dayobs, or dayobs-date parameter's default dynamic, replace that ``default`` field with a ``dynamic_default`` field:
 
 .. code-block:: diff
    :caption: Example of a dynamic default for a date parameter
@@ -21,7 +21,7 @@ To make a date or dayobs parameter's default dynamic, replace that ``default`` f
    -  default: 2024-10-01
    +  dynamic_default: "today"
 
-Dynamic defaults work with both date and dayobs parameters:
+Dynamic defaults work with date, dayobs, and dayobs-date parameters:
 
 .. code-block:: yaml
    :caption: Example of a dynamic default for a dayobs parameter.
@@ -29,8 +29,10 @@ Dynamic defaults work with both date and dayobs parameters:
    parameters:
      start_dayobs:
        type: string
-       format: dayobs
+       format: dayobs-date
        dynamic_default: "today"
+
+In the case of dayobs and dayobs-date, the default follows the UTC-12 timezone that dayobs dates are defined in.
 
 Format for the dynamic_default field
 ====================================

--- a/docs/guides/times-square/authoring/parameter-types.rst
+++ b/docs/guides/times-square/authoring/parameter-types.rst
@@ -72,11 +72,11 @@ See :doc:`dynamic-date-defaults` for more information about the syntax for ``dyn
 
 .. _ts-param-types-dayobs:
 
-DAYOBS
+DayObs
 ======
 
-Rubin Observatory uses DAYOBS to identify an observing night since the DAYOBS is consistent over the course of a night.
-DAYOBS is defined as the date in the UTC-12 timezone, and is represented as a string with eight digits: ``YYYYMMDD``.
+Rubin Observatory uses DayObs to identify an observing night since the DayObs is consistent over the course of a night.
+DayObs is defined as the date formatted as a `natural number in the UTC-12 timezone <https://sitcomtn-032.lsst.io>`__, and is represented as a string with eight digits: ``YYYYMMDD``.
 
 .. code-block:: yaml
    :caption: Notebook YAML sidecar
@@ -85,17 +85,17 @@ DAYOBS is defined as the date in the UTC-12 timezone, and is represented as a st
      start_dayobs:
        type: string
        format: dayobs
-       description: A DAYOBS date
+       description: A DayObs date
        default: "20240101"
 
 .. code-block:: python
    :caption: Notebook parameters cell
 
-   start_dayobs = "20240101"
+   start_dayobs = 20240101
 
-The format of the DAYOBS string is validated, but no processing is done in the parameters cell.
+In the notebook, the dayobs format parameter is assigned as an integer.
 
-Instead of a fixed default DAYOBS, you can also set a *dynamic default* that is relative to the date the notebook is viewed:
+Instead of a fixed default DayObs, you can also set a *dynamic default* that is relative to the date the notebook is viewed:
 
 .. code-block:: yaml
    :caption: Notebook YAML sidecar
@@ -107,6 +107,40 @@ Instead of a fixed default DAYOBS, you can also set a *dynamic default* that is 
        dynamic_default: "yesterday"
 
 See :doc:`dynamic-date-defaults` for more information about the syntax for ``dynamic_default``.
+
+DayObs-Date
+===========
+
+The dayobs-date format is similar to the dayobs format, but assigned as a `datetime.date` object in the notebook.
+The parameter value strings also contain dashes, like a regular date format: ``YYYY-MM-DD``.
+
+.. code-block:: yaml
+   :caption: Notebook YAML sidecar
+
+   parameters:
+     start_dayobs_date:
+       type: string
+       format: dayobs-date
+       description: A DayObs date
+       default: "2024-01-01"
+
+.. code-block:: python
+   :caption: Notebook parameters cell
+
+   import datetime
+
+   start_dayobs_date = datetime.date.fromisoformat("2024-01-01")
+
+dayobs-date parameters also support dynamic defaults, which are relative to the date the notebook is viewed:
+
+.. code-block:: yaml
+   :caption: Notebook YAML sidecar
+
+   parameters:
+     start_dayobs_date:
+       type: string
+       format: dayobs-date
+       dynamic_default: "yesterday"
 
 .. _ts-param-types-datetime:
 

--- a/docs/guides/times-square/authoring/sidecar-schema.rst
+++ b/docs/guides/times-square/authoring/sidecar-schema.rst
@@ -107,12 +107,13 @@ Each parameter is an object with the following fields:
 - ``format`` (*string*, optional) is a format string that describes the expected format of the parameter value:
 
   - ``date`` for date parameters (e.g., ``2024-10-10``)
-  - ``dayobs`` for Rubin DAYOBS dates (e.g., ``20241010``), defined as the date in UTC-12.
+  - ``dayobs`` for Rubin DAYOBS dates (e.g., ``20241010`` as an integer), defined as the date in UTC-12.
+  - ``dayobs-date`` for Rubin DAYOBS dates (e.g., ``2024-10-10``), defined as the date in UTC-12.
   - ``date-time`` for date-time parameters (e.g., ``2024-10-10T04:00Z``).
 
 - ``default`` (*string*, required) is the default value of the parameter. The default must be a valid value for the parameter.
 
-  For ``date`` and ``dayobs`` format parameters, the ``default`` field can be replaced with a ``dynamic_default`` field to set a default relative to the current date. See :doc:`dynamic-date-defaults` for more information.
+  For ``date``, ``dayobs``, and ``dayobs-date`` format parameters, the ``default`` field can be replaced with a ``dynamic_default`` field to set a default relative to the current date. See :doc:`dynamic-date-defaults` for more information.
 
 - ``description`` (*Markdown string*) is the description of the parameter as it appears in the Times Square UI.
 


### PR DESCRIPTION
dayobs-date is a DayObs-type date, but is parsed as a datetime.date in the notebook.

dayobs is now an integer in the notebook following the Rubin metadata conventions.