### PR TITLE
Temporarily disable publishing other editions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,14 +52,14 @@ jobs:
     strategy:
       matrix:
         rsp:
-          - "base"
-          - "idfdev"
-          - "idfint"
+          # - "base"
+          # - "idfdev"
+          # - "idfint"
           - "idfprod"
-          - "summit"
-          - "tucson-teststand"
-          - "usdfdev"
-          - "usdfprod"
+          # - "summit"
+          # - "tucson-teststand"
+          # - "usdfdev"
+          # - "usdfprod"
 
     steps:
       - uses: actions/checkout@v4
@@ -110,14 +110,14 @@ jobs:
     strategy:
       matrix:
         rsp:
-          - "base"
-          - "idfdev"
-          - "idfint"
+          # - "base"
+          # - "idfdev"
+          # - "idfint"
           - "idfprod"
-          - "summit"
-          - "tucson-teststand"
-          - "usdfdev"
-          - "usdfprod"
+          # - "summit"
+          # - "tucson-teststand"
+          # - "usdfdev"
+          # - "usdfprod"
 
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Today we had an issue where the USDF (dev) docs showed up as the default edition. We're disabling publishing docs for anything other than idfprod until we can trace and resolve the issue.