### PR TITLE
DM-54832: Add lsst.rsp Python API reference

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,6 +66,9 @@ jobs:
         with:
           fetch-depth: 0 # full history for rediraffe
 
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -77,6 +77,9 @@ jobs:
         with:
           fetch-depth: 0 # full history for rediraffe
 
+      - name: Install graphviz
+        run: sudo apt-get update && sudo apt-get install -y graphviz
+
       - name: Run tox
         uses: lsst-sqre/run-tox@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Documentation build products
 _build
 
+# automodapi-generated API stub pages for lsst.rsp
+docs/guides/notebooks/lsst.rsp/api/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/conf.py
+++ b/conf.py
@@ -49,6 +49,7 @@ if not rsp_env.portal_url:
 if not rsp_env.nb_url:
     exclude_patterns.append("guides/nb/**/*.rst")
     exclude_patterns.append("guides/getting-started/notebook-first-steps.rst")
+    exclude_patterns.append("guides/notebooks/lsst.rsp/**")
 if not rsp_env.api_tap_url:
     exclude_patterns.append("guides/auth/using-topcat-outside-rsp.rst")
 if not rsp_env.times_square_url:

--- a/docs/guides/notebooks/index.rst
+++ b/docs/guides/notebooks/index.rst
@@ -44,4 +44,17 @@ User guide
    faq/index
 
 
+.. jinja:: rsp
+
+   {% if env.nb_url %}
+   Reference
+   ---------
+
+   .. toctree::
+      :titlesonly:
+
+      lsst.rsp/index
+   {% endif %}
+
+
 Questions? :doc:`Get support </support/index>`.

--- a/docs/guides/notebooks/lsst.rsp/index.rst
+++ b/docs/guides/notebooks/lsst.rsp/index.rst
@@ -1,0 +1,28 @@
+###########################
+lsst.rsp — Python utilities
+###########################
+
+The ``lsst.rsp`` package provides Python helpers for working inside the Rubin Science Platform Notebook aspect.
+These utilities handle common tasks such as connecting to the platform's TAP service, retrieving access tokens, and interacting with other RSP services.
+For example, the :func:`~lsst.rsp.get_tap_service` helper returns a ready-to-use client for querying LSST catalogs:
+
+.. code-block:: python
+
+   from lsst.rsp import get_tap_service
+
+   service = get_tap_service("tap")
+
+The ``lsst.rsp`` package is pre-installed in the RSP Notebook environment, so it is available to import in any notebook or terminal session without additional setup.
+
+This reference documents the latest released version of ``lsst.rsp``.
+To use the package outside the RSP — for example, on a local machine — install it from PyPI:
+
+.. code-block:: bash
+
+   pip install lsst-rsp
+
+.. automodapi:: lsst.rsp
+   :skip: RSPInternalDiscovery
+   :skip: format_bytes
+   :skip: forward_lsst_log
+   :skip: IPythonHandler

--- a/documenteer.toml
+++ b/documenteer.toml
@@ -44,6 +44,7 @@ ignore = [
     'https://data-dev.lsst.cloud',
     'https://data-int.lsst.cloud',
     'https://data.lsst.cloud',
+    'https://id.lsst.cloud',  # COmanage identity portal; blocks the link checker (403)
     'https://summit-lsp.lsst.codes',
     'https://tucson-teststand.lsst.codes',
     'https://usdf-rsp-dev.slac.stanford.edu',

--- a/documenteer.toml
+++ b/documenteer.toml
@@ -7,9 +7,34 @@ version = "Current"
 
 [sphinx]
 extensions = ["sphinx_jinja", "sphinxcontrib.youtube"]
+# Generate the lsst.rsp automodapi stub pages alongside their reference page
+# rather than in the default top-level docs/api/ directory.
+python_api_dir = "guides/notebooks/lsst.rsp/api"
+nitpick_ignore_regex = [
+    # pyvo classes are referenced by bare (unqualified) name in lsst.rsp
+    # docstrings and type annotations; pyvo's object inventory only carries the
+    # fully-qualified names, so these can't be cross-referenced.
+    ["py:.*", "AsyncTAPJob"],
+    ["py:.*", "DatalinkResults"],
+    ["py:.*", "SIA2Service"],
+    ["py:.*", "TAPService"],
+    # Typo in an upstream lsst.rsp docstring (should be RSPDiscovery).
+    ["py:obj", "RESPDiscovery"],
+    # typing.Union is a py:class in CPython's object inventory but is referenced
+    # as py:data by the type-hint renderer.
+    ["py:data", "typing\\.Union"],
+    # logging.Filterer is an undocumented internal base class, absent from
+    # CPython's object inventory.
+    ["py:class", "logging\\.Filterer"],
+]
 
 [sphinx.intersphinx.projects]
 python = "https://docs.python.org/3/"
+astropy = "https://docs.astropy.org/en/stable/"
+numpy = "https://numpy.org/doc/stable/"
+pandas = "https://pandas.pydata.org/docs/"
+pyvo = "https://pyvo.readthedocs.io/en/latest/"
+requests = "https://requests.readthedocs.io/en/latest/"
 
 [sphinx.linkcheck]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "documenteer[guide]>=2.0,<3.0",
+    "documenteer[guide]>=2.1,<3.0",
+    "lsst-rsp==1.0.0",
     "pydantic",
     "Jinja2",
     "sphinx-jinja",


### PR DESCRIPTION
## Summary

- Publish a docstring-generated API reference for the latest released `lsst.rsp` package (`lsst-rsp==1.0.0`) as a new **Reference** section in the Notebook aspect guide, built with `automodapi`.
- Track new `lsst.rsp` releases via a weekly Dependabot pip config, so each release arrives as an isolated PR that CI either passes or flags.
- Keep the strict `-n -W` build clean: extend intersphinx (astropy, numpy, pandas, pyvo, requests) so type references link out, and `nitpick_ignore` the handful that genuinely can't resolve (bare pyvo names in upstream docstrings, a `typing.Union` role mismatch, the undocumented `logging.Filterer` base class, and an upstream `RESPDiscovery` typo).
- Install Graphviz in CI so `automodapi` can render inheritance diagrams; generate stub pages alongside the reference page via `python_api_dir`.
- Exclude the reference in environments without a Notebook service (`if not rsp_env.nb_url`) — inert today since all environments have one, but future-proof.

## Validation steps

- On the ticket-branch LTD preview, open the **Notebook aspect** guide and confirm a new **Reference** section appears, linking "Python helpers, lsst.rsp".
- Open that page and confirm the `lsst.rsp` autosummary table renders, the per-object stub pages are reachable, and the inheritance diagrams display.
- Spot-check that external type references resolve to real links (e.g. `requests.Session` → requests docs, `pyvo.dal.TAPService` → pyvo docs).

## References

- Jira: https://rubinobs.atlassian.net/browse/DM-54832