### PR TITLE
DM-55245: Author-facing Sphinx roles and rsp-only directive

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -1,4 +1,5 @@
 import glob
+import hashlib
 import os
 from pathlib import Path
 from typing import Optional
@@ -30,6 +31,28 @@ env_service = PhalanxEnvService.load(
 )
 
 rsp_env: Optional[PhalanxEnv] = env_service.envs[target_env]
+
+# Enable the in-repo Sphinx extension providing the :rsp-url:/:rsp-link: roles
+# and the .. rsp-only:: directive. ``extensions`` is exported by
+# ``documenteer.conf.guide``. The extension's own setup() runs because it is in
+# ``extensions``; don't also invoke it from the setup() below.
+extensions.append("rspdocs.sphinxext")  # noqa: F405
+
+# Data channels the extension resolves roles/conditions against.
+rsp_all_envs = env_service.envs
+
+# Hash of the discovery JSON that was just loaded. Registered with
+# rebuild="env", this is the sole incremental-rebuild trigger: when discovery
+# data changes its hash changes, so Sphinx reparses every doc and the roles
+# re-bake fresh URLs into the doctrees.
+_discovery_hash = hashlib.sha256()
+for _name in _fetch_envs:
+    _discovery_hash.update(
+        (
+            Path(__file__).parent / "_build" / "discovery" / f"{_name}.json"
+        ).read_bytes()
+    )
+rsp_discovery_hash = _discovery_hash.hexdigest()
 
 _config_template_loader = FileSystemLoader(".")
 _jinja_env = Environment(

--- a/docs/contributing/env-specific-docs.rst
+++ b/docs/contributing/env-specific-docs.rst
@@ -8,120 +8,207 @@ A separate version of this documentation is built for each science platform envi
 The documentation corresponding to the primary, public-facing science platform is always deployed as the main edition at the root URL (https://rsp.lsst.io).
 Other editions are available from https://rsp.lsst.io/v and the Science Platform homepages of each environment also link directly to these editions.
 
-This page describes supported approaches for writing documentation that is different for each environment.
-Each section covers an approach that handles different levels of content customization:
-
-- :ref:`envdocs-substitutions` to customize words and sentences
-- :ref:`envdocs-jinja` to customize paragraphs
-- :ref:`envdocs-jinja-includes` to customize large portions of a page
-
-Besides this documentation, you can also learn from the existing documentation.
-The homepage (:file:`docs/index.rst`) and log-in (:file:`docs/guides/getting-started/get-an-account.rst`) pages demonstrate all the techniques described here.
-
 Information about the RSP environments is fetched at build time from the per-environment `Repertoire <https://repertoire.lsst.io/>`__ service-discovery data that Phalanx publishes at ``https://phalanx.lsst.io/discovery/environments/{env}.json``.
 A small supplementary shim in the `documentation repository <https://github.com/lsst/rsp_lsst_io>`_ (:file:`src/rspdocs/discovery/environments.json`) provides the handful of things discovery doesn't cover, such as human-readable environment titles and the roster of environments to build.
 When the network is unavailable, the build falls back to a local cache (in :file:`_build/discovery/`) and announces the fallback in the build output.
+
+This page describes the supported approaches for writing documentation that differs between environments.
+Reach for them in this order, from the most targeted to the most general:
+
+- :ref:`envdocs-roles` for inline URLs and links to RSP services.
+- :ref:`envdocs-substitutions` for env-specific words and short phrases that a role can't produce.
+- :ref:`envdocs-conditional` to include or exclude whole blocks of content per environment.
+- :ref:`envdocs-jinja` when a branch's text must be *computed* from environment data (interpolation, loops, or expressions).
+- :ref:`envdocs-jinja-includes` to swap large included files.
+
+The roles and the ``rsp-only`` directive are provided by the in-repo :file:`src/rspdocs/sphinxext` Sphinx extension.
+The homepage (:file:`docs/index.rst`) and log-in (:file:`docs/guides/getting-started/get-an-account.rst`) pages demonstrate these techniques.
+
+.. _envdocs-roles:
+
+Linking to RSP services with roles
+==================================
+
+For an inline link or URL to an RSP service, use one of these two roles.
+Each takes a service name — listed in the table below — and resolves it to that service's URL for the environment being built.
+
+``rsp-url``
+    ``:rsp-url:`service``` renders the service's URL as a code literal.
+    For example, ``:rsp-url:`rsp``` renders as :rsp-url:`rsp`.
+
+``rsp-link``
+    ``:rsp-link:`service``` renders a hyperlink to the service whose link text is the URL itself.
+    For example, ``:rsp-link:`rsp``` renders as :rsp-link:`rsp`.
+
+    Give an explicit link title with the familiar ``title <target>`` syntax: ``:rsp-link:`Rubin Science Platform <rsp>``` renders as :rsp-link:`Rubin Science Platform <rsp>`.
+
+Some services aren't deployed in every environment; targeting a service that is absent in the environment being built raises a warning (fatal under ``-W``), which usually means the reference should be wrapped in a matching :ref:`rsp-only <envdocs-conditional>` block.
+
+.. list-table:: Service names
+   :header-rows: 1
+
+   * - Name
+     - Service
+     - In every environment?
+   * - ``rsp``, ``squareone``
+     - RSP homepage
+     - yes
+   * - ``portal``
+     - Portal Aspect
+     - no
+   * - ``nublado``, ``nb``
+     - Notebook Aspect
+     - no
+   * - ``api``
+     - VO API root
+     - no
+   * - ``tap``
+     - TAP service
+     - no
+   * - ``webdav``
+     - WebDAV service
+     - no
+   * - ``times-square``
+     - Times Square
+     - no
+   * - ``tokens``
+     - Access-token page
+     - yes
+   * - ``phalanx-docs``
+     - Phalanx environment docs
+     - yes
 
 .. _envdocs-substitutions:
 
 Using reStructuredText substitutions
 ====================================
 
-For inline content (words or sentences) that changes from one environment to another, such as the name of the science platform environment or a link to the science platform, use `reStructuredText substitutions <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#substitutions>`__.
-You can find these substitutions defined in :file:`rst_epilog.rst.jinja`.
-Some of the key substitutions include:
+For env-specific *prose* — a word, a name, or a derived path that a role can't produce — use `reStructuredText substitutions <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#substitutions>`__.
+These substitutions are defined in :file:`rst_epilog.rst.jinja`, which is itself templated with Jinja so the replacement text can vary by environment.
 
 .. list-table:: Available substitutions
    :header-rows: 1
 
    * - Syntax
      - Example
-   * - ``|rsp|``
-     - |rsp|
    * - ``|rsp-at|``
      - |rsp-at|
    * - ``|rsp-env|``
      - |rsp-env|
    * - ``|rsp-env-link|``
      - |rsp-env-link|
-   * - ``|log-in|``
-     - |log-in|
-   * - ``|open-nb-aspect|``
-     - |open-nb-aspect|
-   * - ``|rsp-url|``
-     - |rsp-url|
-   * - ``|nb-url|``
-     - |nb-url|
+   * - ``|rsp-quotas-url|``
+     - |rsp-quotas-url|
+   * - ``|rsp-quotas-page|``
+     - |rsp-quotas-page|
+   * - ``|webdav-server|``
+     - |webdav-server|
 
-The :file:`rst_epilog.rst.jinja` file is templated using Jinja.
+Prefer a :ref:`role <envdocs-roles>` whenever you only need a service's URL or a link to it — the roles replaced the per-service URL and link substitutions the docs used to define.
+
+.. _envdocs-conditional:
+
+Conditional content with the ``rsp-only`` directive
+===================================================
+
+To include a block of content only in certain environments, wrap it in the ``rsp-only`` directive:
+
+.. code-block:: rst
+
+   .. rsp-only:: primary
+
+      This content appears only in the primary (public) build.
+
+The directive takes one or more bare *condition tokens*, which may be:
+
+- a **service name** (from the table above) — true where that service is deployed;
+- an **environment name** (``base``, ``idfdev``, ``idfint``, ``idfprod``, ``summit``, ``tucson-teststand``, ``usdfdev``, ``usdfprod``) — true only in that environment; or
+- the keyword ``primary`` — synonymous with ``idfprod``, the primary environment, whose documentation is the default edition.
+
+By default every token must hold (logical AND):
+
+.. code-block:: rst
+
+   .. rsp-only:: portal nublado
+
+      This content appears only where both the Portal and Notebook aspects exist.
+
+Use the ``:any:`` option for a logical OR, and the ``:not:`` option to negate the result:
+
+.. code-block:: rst
+
+   .. rsp-only:: summit base
+      :any:
+
+      This content appears in the summit or base environments.
+
+   .. rsp-only:: primary
+      :not:
+
+      This content appears in every environment except the primary one.
+
+For an "AND of an OR" condition, nest ``rsp-only`` directives.
+
+Unlike Sphinx's built-in `only <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-only>`__ directive, ``rsp-only`` excludes non-matching content at parse time: excluded content never enters the doctree, so it can't leak into the table of contents, the index, or search results.
+This is safe here because each environment is built separately (one ``sphinx-build`` per environment), so ``rsp-only`` is the right tool for conditional content — there's no need to avoid it the way you would avoid ``only``.
 
 .. _envdocs-jinja:
 
 Using Jinja templating
 ======================
 
-If different environments require alternative versions of whole paragraphs, use the ``jinja`` directive, available through sphinx-jinja_, to display different content based on Jinja_ control-flow syntax:
+The ``rsp-only`` directive only *includes or excludes* static reStructuredText.
+Reach for the ``jinja`` directive — available through sphinx-jinja_ — when a branch's text has to be *computed* rather than merely shown or hidden: interpolating an expression like ``{{ env.title }}``, running a loop, or testing an ``env`` attribute that isn't a service name, an environment name, or ``primary``.
+
+The deciding question is not how many branches you have, but whether the prose inside a branch depends on a value — and one that no ``rsp-url``/``rsp-link`` role or substitution already provides.
+If every branch is self-contained rST, prefer stacking :ref:`rsp-only <envdocs-conditional>` blocks; use ``jinja`` only when a branch needs to *say something* built from the environment's data.
+
+For example, a three-way switch whose branches are worded differently *and* each interpolates an environment value that has no substitution of its own (here the short title ``env.title`` and the ``env.domain`` host):
 
 .. code-block:: rst
 
    .. jinja:: rsp
 
       {% if env.is_primary %}
-      This paragraph appears in the documentation for the
-      primary science platform environment.
+      The public Science Platform is served at {{ env.domain }}.
 
-      {% elif env.name in ("base", "summit") %}
-      This paragraph appears in documentation for the base
-      and summit.
+      {% elif env.name in ("idfint", "idfdev") %}
+      {{ env.title }} is a staff integration environment.
 
-      {% elif env.name == "idfprod" %}
-      This paragraph appears only for the "IDF prod" environment.
-
+      {% else %}
+      {{ env.title }} runs at {{ env.domain }} for internal use.
       {% endif %}
 
 The argument to the ``jinja`` directive is always ``rsp``.
-The ``env`` variable contains information about that environment.
+Inside it, ``env`` is the environment being built (an instance of ``rspdocs.discovery.models.PhalanxEnv``, so any of its attributes are available), and ``all_envs`` maps environment names to their ``PhalanxEnv``.
+As with any Sphinx directive, indent the content consistently with respect to the directive's scope, as shown above.
 
-When using the ``jinja`` directive, as with any Sphinx directive, ensure that content is indented consistently with respect to the scope of the directive, as shown above.
+Two things to keep in mind:
+
+- For a simple two-way include/exclude, prefer :ref:`envdocs-conditional`: it reads more clearly and keeps excluded content out of search and the table of contents.
+- Each build fetches only the target environment and the primary environment (for speed), so ``all_envs`` holds just those one or two entries — a ``{% for %}`` loop over it will **not** enumerate all eight environments.
 
 .. _envdocs-jinja-includes:
 
-Using Jinja templating with source file includes (\*.in.rst)
-============================================================
+Using source file includes (\*.in.rst) with rsp-only and jinja
+==============================================================
 
-The previous approach works well for templating paragraphs, however it is inconvenient to write inside a Jinja directive (within the scope of Jinja syntax, at that).
-To customize large portions of text, you can use the include statement in combination with Jinja:
+Both the ``rsp-only`` and ``jinja`` approaches work well for tailoring specific paragraphs for different environments, but writing a large amount of content inside a directive is inconvenient.
+To customize large portions of text, you can combine the ``rsp-only`` directive (or a ``jinja`` directive for multi-way switches) with the ``include`` directive:
 
 .. code-block:: rst
 
-   .. jinja:: rsp
+   .. rsp-only:: primary
 
-      {% if env.is_primary %}
       .. include:: the-page.primary.in.rst
 
-      {% else %}
+   .. rsp-only:: primary
+      :not:
+
       .. include:: the-page.notprimary.in.rst
 
-      {% endif %}
-
-This code sample inserts content from the included source files, either ``the-page.primary.in.rst`` or ``the-page.notprimary.in.rst``.
-Those included files are in the familiar reStructuredText syntax (you shouldn't need to use further Jinja syntax within them, though can certainly use :ref:`substititions <envdocs-substitutions>`).
+This inserts content from the included source files, either ``the-page.primary.in.rst`` or ``the-page.notprimary.in.rst``.
+Those included files are in the familiar reStructuredText syntax (you shouldn't need further Jinja syntax within them, though you can certainly use :ref:`roles <envdocs-roles>` and :ref:`substitutions <envdocs-substitutions>`).
 
 The included files **must** have a ``.in.rst`` suffix so that the Sphinx build won't incorporate those files as separate pages.
 Our further convention is to prefix the name with the root name of the page, followed by a description of the environment or context where the content applies.
-
-.. _envdocs-only:
-
-Avoiding the "only" directive
-=============================
-
-Besides the techniques described above, Sphinx also provides an `only <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html?highlight=only#directive-only>`__ directive to control content based on Sphinx build tags.
-As part of the tox-based build, the environment name is available as a tag:
-
-.. code-block:: rst
-
-   .. only:: idfprod
-
-      This sentence appears only for the ``idfprod`` build of the docs.
-
-You should avoid this approach, however, and use one of the earlier techniques instead, because the ``only`` directive does not work well with reStructuredText labels and the built-in Sphinx search.

--- a/docs/guides/api/index.rst
+++ b/docs/guides/api/index.rst
@@ -2,10 +2,11 @@
 API aspect
 ##########
 
-.. jinja:: rsp
+.. rsp-only:: primary
 
-   {% if env.is_primary %}
    .. include:: api.primary.in.rst
-   {% else %}
+
+.. rsp-only:: primary
+   :not:
+
    .. include:: api.primary.in.rst
-   {% endif %}

--- a/docs/guides/auth/using-topcat-outside-rsp.rst
+++ b/docs/guides/auth/using-topcat-outside-rsp.rst
@@ -24,7 +24,7 @@ This example specifically shows how to access table data from the Science Platfo
 
 #. This will bring up a window with a list of available TAP services.
    We want to use a service with a known endpoint.
-   Enter |rsp-tap-url-code| in the box at the bottom of the page labeled :guilabel:`TAP URL`.
+   Enter :rsp-url:`tap` in the box at the bottom of the page labeled :guilabel:`TAP URL`.
 
    .. image:: images/topcat-tap-window.png
       :alt: The TAP service configuration window.

--- a/docs/guides/getting-started/get-an-account.rst
+++ b/docs/guides/getting-started/get-an-account.rst
@@ -2,18 +2,17 @@
 Getting an account on the RSP
 #############################
 
-.. jinja:: rsp
+.. rsp-only:: primary
 
-   {% if env.is_primary %}
    .. include:: user-step-by-step.primary.in.rst
 
+.. rsp-only:: primary
+   :not:
 
-   {% else %}
    .. important::
 
       This |rsp-at| is for internal Rubin Observatory engineering and testing.
 
-      If you are a science community member, switch to the main documentation at {{all_envs.primary.ltd_url_prefix}}.
+      If you are a science community member, switch to the main documentation at https://rsp.lsst.io/.
 
    To get an account, request one from the RSP environment's administrators or your manager.
-   {% endif %}

--- a/docs/guides/getting-started/user-step-by-step.primary.in.rst
+++ b/docs/guides/getting-started/user-step-by-step.primary.in.rst
@@ -11,7 +11,7 @@ Before getting started
 
 2. Have an account with an InCommon institution, GitHub, or ORCID.
 
-   - The |rsp-at| (|rsp-url|) uses the CILogon service (operated by NCSA) to allow you to gain RSP access with an existing identity.
+   - The |rsp-at| (:rsp-link:`rsp`) uses the CILogon service (operated by NCSA) to allow you to gain RSP access with an existing identity.
    - Accepted identity providers include institutional members of the `InCommon federation <https://incommon.org/>`__ and other providers like `GitHub <https://github.com/>`__ and `ORCID <https://orcid.org/>`__.
    - If your institution does not participate in InCommon (i.e., if it does not appear in the drop-down menu in step 2, below), use GitHub or ORCID (accounts are free).
    - The RSP's system asks your identity provider’s system if you are who you say you are.
@@ -28,7 +28,7 @@ Before getting started
 Video
 =====
 
-This video shows the steps for creating a new account on |rsp-url|:
+This video shows the steps for creating a new account on :rsp-link:`rsp`:
 
 .. vimeo:: 800911530
 
@@ -41,7 +41,7 @@ Step-by-step
 
       .. grid-item::
 
-         - Go to the RSP at |rsp-url| in your browser.
+         - Go to the RSP at :rsp-link:`rsp` in your browser.
          - Click :guilabel:`Log In` at the upper right.
 
       .. grid-item::
@@ -117,7 +117,7 @@ Step-by-step
 
 9. Log in and get started:
 
-   - After receiving the email notification that your account is approved, return to the RSP at |rsp-url| and log in.
+   - After receiving the email notification that your account is approved, return to the RSP at :rsp-link:`rsp` and log in.
    - Find information about the available data releases and resources for scientists, such as documentation and tutorials, at `rubinobservatory.org <https://rubinobservatory.org/for-scientists>`__.
 
 10. Link a non-institutional identity:

--- a/docs/guides/life/quotas.rst
+++ b/docs/guides/life/quotas.rst
@@ -22,7 +22,7 @@ If you are a heavy user of the RSP APIs, make sure to read the relevant section 
 The Quotas page
 ===============
 
-You can find your |rsp-quotas-page| under your user profile, accessible through the |rsp-url| home page:
+You can find your |rsp-quotas-page| under your user profile, accessible through the :rsp-link:`rsp` home page:
 
 .. figure:: quotas_ani.gif
    :alt: animation for how to navigate to the Quotas page

--- a/docs/guides/recovery/index.rst
+++ b/docs/guides/recovery/index.rst
@@ -2,18 +2,17 @@
 Recover from access issues
 ##########################
 
-.. jinja:: rsp
+.. rsp-only:: primary
 
-   {% if env.is_primary %}
    .. include:: user-recovery.primary.in.rst
 
+.. rsp-only:: primary
+   :not:
 
-   {% else %}
    .. important::
 
       This |rsp-at| is for internal Rubin Observatory engineering and testing.
 
-      If you are a science community member, switch to the main documentation at {{all_envs.primary.ltd_url_prefix}}.
+      If you are a science community member, switch to the main documentation at https://rsp.lsst.io/.
 
    To recover a staff account, contact one of the RSP environment's administrators or your manager.
-   {% endif %}

--- a/docs/guides/times-square/authoring/authoring-howto.rst
+++ b/docs/guides/times-square/authoring/authoring-howto.rst
@@ -2,7 +2,7 @@
 How to write a notebook for Times Square
 ########################################
 
-If you know how to create a Jupyter notebook, publishing a notebook to |times-square| will be familiar.
+If you know how to create a Jupyter notebook, publishing a notebook to :rsp-link:`Times Square <times-square>` will be familiar.
 This page outlines the basic steps for adding and authoring a notebook for Times Square, and links to further documentation.
 
 1. Setting up on the Science Platform Notebook Aspect
@@ -24,7 +24,7 @@ You'll "publish" your notebook to Times Square by pushing it to GitHub.
 
 .. tip::
 
-   To see what repositories are available on Times Square, visit the |times-square| homepage.
+   To see what repositories are available on Times Square, visit the :rsp-link:`Times Square <times-square>` homepage.
    The sidebar shows what repositories already host notebooks.
 
    If an existing repository doesn't fit your needs, you can create a new repository on GitHub and set it up for Times Square.
@@ -208,4 +208,4 @@ Whenever you push an update, Times Square will re-check and re-run the notebook.
 Therefore you can keep trying your notebook on Times Square until you're satisfied with the results.
 
 When you're ready to merge the pull request, click the "Merge pull request" button on the pull request page.
-At this point, the notebook will be available from the |times-square| homepage.
+At this point, the notebook will be available from the :rsp-link:`Times Square <times-square>` homepage.

--- a/docs/guides/times-square/index.rst
+++ b/docs/guides/times-square/index.rst
@@ -2,7 +2,7 @@
 Times Square
 ############
 
-|times-square| lets you share Jupyter Notebooks as linkable web pages.
+:rsp-link:`Times Square <times-square>` lets you share Jupyter Notebooks as linkable web pages.
 You can parameterize those notebooks for users to see results for different inputs.
 Times Square is great for sharing reports and analyses.
 

--- a/docs/guides/webdav/index.rst
+++ b/docs/guides/webdav/index.rst
@@ -28,7 +28,7 @@ WebDAV
     --------------------------
 
 
-    3. Navigate to |webdav-app| and wait for the page to load (the delay is the time it takes to start your personal WebDAV server if it's not running already).
+    3. Navigate to :rsp-link:`webdav` and wait for the page to load (the delay is the time it takes to start your personal WebDAV server if it's not running already).
 
     4. You can now connect to your WebDAV server with the tool of your choice. While there are dedicated clients, most operating systems support WebDAV in their file browsing built-in tools:
 

--- a/rst_epilog.rst.jinja
+++ b/rst_epilog.rst.jinja
@@ -1,7 +1,10 @@
 .. Templated substitutions ====================================================
+..
+.. Inline URLs and links are provided by the :rsp-url: and :rsp-link: roles
+.. from the rspdocs.sphinxext extension; these substitutions cover only the
+.. env-specific *prose* and derived paths those roles can't produce. See
+.. docs/contributing/env-specific-docs.rst.
 
-.. |rsp| replace:: `Rubin Science Platform <{{ env.squareone_url }}>`__
-.. |rsp-settings-url| replace:: ``<{{ env.squareone_url }}settings``
 .. |rsp-quotas-url| replace:: ``{{ env.squareone_url}}settings/quotas``
 .. |rsp-quotas-page| replace:: `Quotas page <{{ env.squareone_url}}settings/quotas>`__
 {% if env.is_primary %}
@@ -11,27 +14,8 @@
 {% endif %}
 .. |rsp-env| replace:: {{ env.title_full }}
 .. |rsp-env-link| replace:: `{{ env.title_full }} <{{ env.squareone_url }}>`__
-{% if env.api_url %}
-.. |rsp-api-url| replace:: ``{{ env.api_url }}``
-{% endif %}
-{% if env.nb_url %}
-.. |log-in| replace:: `Log into the Notebook Aspect <{{ env.nb_url }}>`__
-.. |open-nb-aspect| replace:: `Open the Notebook Aspect <{{ env.nb_url }}>`__
-{% endif %}
-.. |rsp-url| replace:: `{{env.squareone_url}} <{{env.squareone_url}}>`__
-{% if env.nb_url %}
-.. |nb-url| replace:: `{{env.nb_url}} <{{env.nb_url}}>`__
-{% endif %}
-{% if env.api_tap_url %}
-.. |rsp-tap-url| replace:: `{{env.api_tap_url}} <{{env.api_tap_url}}>`__
-.. |rsp-tap-url-code| replace:: ``{{env.api_tap_url}}``
-{% endif %}
-{% if env.times_square_url %}
-.. |times-square| replace:: `Times Square <{{env.times_square_url}}>`__
-{% endif %}
 {% if env.api_webdav_url %}
-.. |webdav-app| replace:: `{{env.api_webdav_url}} <{{env.api_webdav_url}}>`__
-.. |webdav-server| replace:: ``{{env.api_webdav_url}}(your_username)``
+.. |webdav-server| replace:: ``{{ env.api_webdav_url }}(your_username)``
 {% endif %}
 
 .. Templated link targets =====================================================

--- a/src/rspdocs/sphinxext/__init__.py
+++ b/src/rspdocs/sphinxext/__init__.py
@@ -1,0 +1,85 @@
+"""In-repo Sphinx extension exposing author-facing roles and a conditional
+directive backed by Repertoire discovery data.
+
+The extension provides:
+
+* ``:rsp-url:`service``` -- a code literal of a service's URL,
+* ``:rsp-link:`service``` -- an external hyperlink to a service, and
+* ``.. rsp-only::`` -- content included only in matching environments.
+
+All three resolve against the `~rspdocs.discovery.models.PhalanxEnv` for the
+environment being built, supplied through the ``rsp_env`` config value (see
+:file:`conf.py`).
+"""
+
+from __future__ import annotations
+
+from importlib.metadata import version
+from typing import Any
+
+from sphinx.application import Sphinx
+from sphinx.errors import ConfigError
+
+from ..discovery.models import PhalanxEnv
+from .directives import RspOnly
+from .roles import RspLinkRole, RspUrlRole
+from .services import KNOWN_ENVS, SERVICE_ATTRS
+
+__all__ = ["setup"]
+
+
+def _check_token_namespaces_disjoint() -> None:
+    """Assert the condition token name-spaces do not collide.
+
+    ``rsp-only`` accepts bare tokens that may be a service name, an environment
+    name, or ``primary``. Those three sets must stay pairwise disjoint or a
+    token would be ambiguous; a future naming collision should fail the build
+    loudly rather than resolve silently to the wrong meaning.
+    """
+    services = set(SERVICE_ATTRS)
+    envs = set(KNOWN_ENVS)
+    primary = {"primary"}
+    collisions = {
+        "service names and environment names": services & envs,
+        "service names and 'primary'": services & primary,
+        "environment names and 'primary'": envs & primary,
+    }
+    reported = {
+        label: sorted(overlap)
+        for label, overlap in collisions.items()
+        if overlap
+    }
+    if reported:
+        raise ConfigError(
+            "rspdocs.sphinxext condition token name-spaces must be disjoint, "
+            f"but these overlap: {reported}"
+        )
+
+
+def setup(app: Sphinx) -> dict[str, Any]:
+    """Register the rspdocs roles, directive, and config values."""
+    _check_token_namespaces_disjoint()
+
+    # Data channels for the current build. These are excluded from the ``env``
+    # rebuild filter (rebuild="") so their pickled comparison never triggers a
+    # rebuild; ``rsp_discovery_hash`` below is the single rebuild trigger.
+    app.add_config_value(
+        "rsp_env", None, rebuild="", types=(PhalanxEnv, type(None))
+    )
+    app.add_config_value("rsp_all_envs", None, rebuild="")
+
+    # The only rebuild trigger: when discovery data changes its hash changes,
+    # so Sphinx marks all docs for reparse and the roles re-bake fresh URLs
+    # into the doctrees (roles resolve at read time, hence this is required for
+    # incremental-build correctness).
+    app.add_config_value("rsp_discovery_hash", "", rebuild="env", types=(str,))
+
+    app.add_role("rsp-url", RspUrlRole())
+    app.add_role("rsp-link", RspLinkRole())
+    app.add_directive("rsp-only", RspOnly)
+
+    return {
+        "version": version("rspdocs"),
+        "parallel_read_safe": True,
+        "parallel_write_safe": True,
+    }

--- a/src/rspdocs/sphinxext/directives.py
+++ b/src/rspdocs/sphinxext/directives.py
@@ -1,0 +1,50 @@
+"""The ``rsp-only`` directive: include content only in matching environments.
+
+Arguments are bare tokens that mix service names, environment names, and the
+``primary`` keyword (the token name-spaces are kept disjoint by a guard in
+`~rspdocs.sphinxext.setup`). By default all tokens must hold (AND); ``:any:``
+switches to OR and ``:not:`` negates the result. Excluded content is never
+parsed into the doctree, so it cannot leak into the table of contents, the
+index, or search.
+"""
+
+from __future__ import annotations
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
+
+from .logging import warn_unknown_condition
+from .services import resolve_condition
+
+__all__ = ["RspOnly"]
+
+
+class RspOnly(SphinxDirective):
+    """Emit the directive body only when its condition matches the env."""
+
+    required_arguments = 1
+    optional_arguments = 1
+    final_argument_whitespace = True
+    option_spec = {"any": directives.flag, "not": directives.flag}
+    has_content = True
+
+    def run(self) -> list[nodes.Node]:
+        # required_arguments=1 + optional_arguments=1 + final_argument_
+        # whitespace captures every space-separated token across (at most) two
+        # arguments; rejoin and re-split to recover the full token list.
+        tokens = " ".join(self.arguments).split()
+        env = self.config.rsp_env
+        results: list[bool] = []
+        for token in tokens:
+            result = resolve_condition(env, token)
+            if result is None:
+                warn_unknown_condition(token, location=self.get_location())
+                result = False
+            results.append(result)
+        match = any(results) if "any" in self.options else all(results)
+        if "not" in self.options:
+            match = not match
+        if not match:
+            return []
+        return self.parse_content_to_nodes(allow_section_headings=True)

--- a/src/rspdocs/sphinxext/logging.py
+++ b/src/rspdocs/sphinxext/logging.py
@@ -1,0 +1,84 @@
+"""Shared Sphinx logging for the rspdocs extension.
+
+All warnings emitted by the extension use the ``rspdocs`` warning *type* with a
+descriptive *subtype*, so they are
+
+* precise -- every call passes ``location`` for a ``file:line`` reference,
+* fatal under ``sphinx-build -W`` (Sphinx counts non-suppressed warnings), and
+* individually silenceable via ``suppress_warnings`` (for example
+  ``suppress_warnings = ["rspdocs.unknown-service"]`` or the whole family with
+  ``["rspdocs"]``).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sphinx.util import logging
+
+__all__ = [
+    "WARNING_TYPE",
+    "UNKNOWN_SERVICE",
+    "UNAVAILABLE_SERVICE",
+    "UNKNOWN_CONDITION",
+    "warn_unknown_service",
+    "warn_unavailable_service",
+    "warn_unknown_condition",
+]
+
+logger = logging.getLogger(__name__)
+
+WARNING_TYPE = "rspdocs"
+"""The Sphinx warning ``type`` for every warning this extension emits."""
+
+UNKNOWN_SERVICE = "unknown-service"
+"""Subtype: a role targets a token that is not a known service name."""
+
+UNAVAILABLE_SERVICE = "unavailable-service"
+"""Subtype: a role targets a known service that is absent in this env."""
+
+UNKNOWN_CONDITION = "unknown-condition"
+"""Subtype: an ``rsp-only`` token that isn't a service/env/``primary``."""
+
+
+def warn_unknown_service(name: str, *, location: Any) -> None:
+    """Warn that ``name`` is not a recognized RSP service token."""
+    logger.warning(
+        "unknown RSP service %r; expected one of the documented service "
+        "tokens (see docs/contributing/env-specific-docs.rst)",
+        name,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=UNKNOWN_SERVICE,
+    )
+
+
+def warn_unavailable_service(
+    name: str, env_name: str, *, location: Any
+) -> None:
+    """Warn that service ``name`` is not available in ``env_name``.
+
+    This usually means the reference should be wrapped in a matching
+    ``.. rsp-only::`` block so it is only emitted where the service exists.
+    """
+    logger.warning(
+        "RSP service %r is not available in the %r environment; wrap the "
+        "reference in a matching '.. rsp-only::' block",
+        name,
+        env_name,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=UNAVAILABLE_SERVICE,
+    )
+
+
+def warn_unknown_condition(token: str, *, location: Any) -> None:
+    """Warn that ``token`` is not a valid ``rsp-only`` condition."""
+    logger.warning(
+        "unknown rsp-only condition %r; expected a service name, an "
+        "environment name, or 'primary'",
+        token,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=UNKNOWN_CONDITION,
+    )

--- a/src/rspdocs/sphinxext/roles.py
+++ b/src/rspdocs/sphinxext/roles.py
@@ -1,0 +1,61 @@
+"""Author-facing roles that resolve service URLs from discovery data.
+
+``:rsp-url:`service``` emits a code literal of the service's URL for the
+environment being built; ``:rsp-link:`service``` (or
+``:rsp-link:`Title <service>```) emits a real external hyperlink. Because both
+resolve at parse time, URLs can appear in code literals, tables, admonitions,
+and lists, and ``:rsp-link:`` references are crawled by ``linkcheck``.
+"""
+
+from __future__ import annotations
+
+from docutils import nodes
+from sphinx.util.docutils import ReferenceRole, SphinxRole
+
+from .logging import warn_unavailable_service, warn_unknown_service
+from .services import is_known_service, resolve_url
+
+__all__ = ["RspUrlRole", "RspLinkRole"]
+
+
+class RspUrlRole(SphinxRole):
+    """``:rsp-url:`service``` -> a code literal of the service's URL."""
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        service = self.text
+        if not is_known_service(service):
+            warn_unknown_service(service, location=self.get_location())
+            return [nodes.literal("", service)], []
+        env = self.config.rsp_env
+        url = resolve_url(env, service)
+        if url is None:
+            warn_unavailable_service(
+                service, env.name, location=self.get_location()
+            )
+            return [nodes.literal("", service)], []
+        return [nodes.literal("", url)], []
+
+
+class RspLinkRole(ReferenceRole):
+    """``:rsp-link:`service``` -> an external hyperlink to the service.
+
+    With no explicit title the link text is the URL itself (matching the prior
+    ``|rsp-url|``/``|nb-url|`` substitutions); ``:rsp-link:`Title <service>```
+    uses ``Title`` as the link text.
+    """
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        service = self.target
+        if not is_known_service(service):
+            warn_unknown_service(service, location=self.get_location())
+            return [nodes.Text(self.title)], []
+        env = self.config.rsp_env
+        url = resolve_url(env, service)
+        if url is None:
+            warn_unavailable_service(
+                service, env.name, location=self.get_location()
+            )
+            return [nodes.Text(self.title)], []
+        display = self.title if self.has_explicit_title else url
+        node = nodes.reference("", display, refuri=url, internal=False)
+        return [node], []

--- a/src/rspdocs/sphinxext/services.py
+++ b/src/rspdocs/sphinxext/services.py
@@ -1,0 +1,86 @@
+"""Single source of truth mapping service names and conditions to discovery
+data.
+
+This module is deliberately free of any Sphinx dependency so it can be unit
+tested against `~rspdocs.discovery.models.PhalanxEnv` objects directly.
+
+A *service token* names a user-facing RSP service; it resolves to an attribute
+on `PhalanxEnv`. A service is *available* in an environment iff that attribute
+resolves to a non-``None`` URL. A *condition token* (used by the ``rsp-only``
+directive) is a service token, an environment name, or the special keyword
+``primary``.
+"""
+
+from __future__ import annotations
+
+from ..discovery.metadata import load_environments_metadata
+from ..discovery.models import PhalanxEnv
+
+__all__ = [
+    "SERVICE_ATTRS",
+    "KNOWN_ENVS",
+    "is_known_service",
+    "resolve_url",
+    "is_available",
+    "resolve_condition",
+]
+
+SERVICE_ATTRS: dict[str, str] = {
+    "rsp": "squareone_url",
+    "squareone": "squareone_url",
+    "portal": "portal_url",
+    "nublado": "nb_url",
+    "nb": "nb_url",
+    "api": "api_url",
+    "tap": "api_tap_url",
+    "webdav": "api_webdav_url",
+    "times-square": "times_square_url",
+    "tokens": "gafaelfawr_tokens_url",
+    "phalanx-docs": "phalanx_docs_url",
+}
+"""Canonical service token -> `PhalanxEnv` attribute holding its URL."""
+
+KNOWN_ENVS: frozenset[str] = frozenset(
+    load_environments_metadata().build_roster
+)
+"""Every environment name in the build roster (all environments, not just the
+subset fetched for a given build).
+"""
+
+
+def is_known_service(name: str) -> bool:
+    """Return whether ``name`` is a recognized service token."""
+    return name in SERVICE_ATTRS
+
+
+def resolve_url(env: PhalanxEnv, name: str) -> str | None:
+    """Return the URL for service ``name`` in ``env``, or ``None``.
+
+    ``None`` is returned both for an unknown service token and for a known
+    service that is not deployed in this environment. Callers that need to
+    distinguish the two should check `is_known_service` first.
+    """
+    attr = SERVICE_ATTRS.get(name)
+    url = getattr(env, attr) if attr else None
+    return str(url) if url is not None else None
+
+
+def is_available(env: PhalanxEnv, name: str) -> bool:
+    """Return whether service ``name`` has a URL in ``env``."""
+    return resolve_url(env, name) is not None
+
+
+def resolve_condition(env: PhalanxEnv, token: str) -> bool | None:
+    """Evaluate an ``rsp-only`` condition token against ``env``.
+
+    Returns ``True``/``False`` for a recognized token, or ``None`` when the
+    token is neither a known service, a known environment name, nor
+    ``primary``.
+    """
+    if token == "primary":
+        return env.is_primary
+    if token in KNOWN_ENVS:
+        return env.name == token
+    if is_known_service(token):
+        return is_available(env, token)
+    return None

--- a/tests/sphinxext/conftest.py
+++ b/tests/sphinxext/conftest.py
@@ -1,0 +1,78 @@
+"""Shared fixtures for the sphinxext test suite."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterator, Mapping, Sequence
+from pathlib import Path
+
+import pytest
+from rubin.repertoire import Discovery
+from sphinx.testing.util import SphinxTestApp
+
+from rspdocs.discovery.metadata import EnvMeta
+from rspdocs.discovery.models import PhalanxEnv
+
+# Re-export the discovery fixtures so tests here can build PhalanxEnv objects
+# from the same captured discovery JSON used by the discovery test suite.
+from tests.discovery.conftest import discovery_data_dir, discovery_texts
+
+# ``__all__`` marks the imports above as an intentional re-export (they are
+# consumed as pytest fixtures, not referenced by name in this module).
+__all__ = ["discovery_data_dir", "discovery_texts"]
+
+
+@pytest.fixture
+def make_env(discovery_data_dir: Path) -> Callable[..., PhalanxEnv]:
+    """Return a factory that builds a `PhalanxEnv` from a discovery fixture."""
+
+    def _make(name: str, *, hidden_services: Sequence[str] = ()) -> PhalanxEnv:
+        text = (discovery_data_dir / f"{name}.json").read_text()
+        discovery = Discovery.model_validate_json(text)
+        meta = EnvMeta(
+            title=name,
+            title_full=name,
+            hidden_services=list(hidden_services),
+        )
+        return PhalanxEnv.from_discovery(discovery, name=name, meta=meta)
+
+    return _make
+
+
+@pytest.fixture
+def app_factory(
+    tmp_path: Path,
+) -> Iterator[Callable[..., SphinxTestApp]]:
+    """Return a factory that builds a `SphinxTestApp` with the extension on.
+
+    Each call gets a fresh source directory, so a single test can exercise
+    several environments. Every app created through the factory is torn down at
+    the end of the test.
+    """
+    created: list[SphinxTestApp] = []
+    count = 0
+
+    def _make(
+        env: PhalanxEnv,
+        all_envs: Mapping[str, PhalanxEnv] | None = None,
+        confoverrides: Mapping[str, object] | None = None,
+    ) -> SphinxTestApp:
+        nonlocal count
+        count += 1
+        srcdir = tmp_path / f"src{count}"
+        srcdir.mkdir()
+        (srcdir / "conf.py").write_text("extensions = ['rspdocs.sphinxext']\n")
+        (srcdir / "index.rst").write_text("Index\n=====\n")
+        overrides: dict[str, object] = {
+            "rsp_env": env,
+            "rsp_all_envs": dict(all_envs) if all_envs else {env.name: env},
+            "rsp_discovery_hash": "test",
+        }
+        if confoverrides:
+            overrides.update(confoverrides)
+        app = SphinxTestApp(srcdir=srcdir, confoverrides=overrides)
+        created.append(app)
+        return app
+
+    yield _make
+    for app in created:
+        app.cleanup()

--- a/tests/sphinxext/test_directive.py
+++ b/tests/sphinxext/test_directive.py
@@ -1,0 +1,114 @@
+"""Doctree tests for the ``rsp-only`` directive."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from docutils import nodes
+from sphinx.testing.restructuredtext import parse
+from sphinx.testing.util import SphinxTestApp
+
+from rspdocs.discovery.models import PhalanxEnv
+
+MakeEnv = Callable[..., PhalanxEnv]
+AppFactory = Callable[..., SphinxTestApp]
+
+MARKER = "CONDITIONAL-BODY"
+"""Sentinel text used to detect whether the directive body was emitted."""
+
+
+def _snippet(*tokens: str, option: str = "") -> str:
+    """Build an ``rsp-only`` snippet whose body contains ``MARKER``."""
+    lines = [".. rsp-only:: " + " ".join(tokens)]
+    if option:
+        lines.append(f"   {option}")
+    lines += ["", f"   {MARKER}", ""]
+    return "\n".join(lines)
+
+
+def _emitted(doctree: nodes.document) -> bool:
+    return MARKER in doctree.astext()
+
+
+def test_included_for_primary(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """``primary`` includes the body in the primary environment."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, _snippet("primary"))
+    assert _emitted(doctree)
+    assert app.warning.getvalue() == ""
+
+
+def test_excluded_for_nonprimary(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """Excluded content never enters the doctree."""
+    app = app_factory(make_env("base"))
+    doctree = parse(app, _snippet("primary"))
+    assert not _emitted(doctree)
+
+
+def test_env_name_token(make_env: MakeEnv, app_factory: AppFactory) -> None:
+    """An environment-name token matches only that environment."""
+    app = app_factory(make_env("base"))
+    assert _emitted(parse(app, _snippet("base")))
+    assert not _emitted(parse(app, _snippet("idfprod")))
+
+
+def test_service_token(make_env: MakeEnv, app_factory: AppFactory) -> None:
+    """A service token includes content only where the service exists."""
+    idfprod = app_factory(
+        make_env("idfprod", hidden_services=["times-square"])
+    )
+    assert _emitted(parse(idfprod, _snippet("tap")))
+    base = app_factory(make_env("base"))
+    assert not _emitted(parse(base, _snippet("tap")))
+
+
+def test_default_conjunction_is_and(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """Multiple tokens default to AND: base has portal but not tap."""
+    app = app_factory(make_env("base"))
+    assert not _emitted(parse(app, _snippet("portal", "tap")))
+
+
+def test_any_option_is_or(make_env: MakeEnv, app_factory: AppFactory) -> None:
+    """``:any:`` switches to OR: base has portal, so the body is emitted."""
+    app = app_factory(make_env("base"))
+    assert _emitted(parse(app, _snippet("portal", "tap", option=":any:")))
+
+
+def test_not_option_negates(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """``:not:`` negates the match."""
+    base = app_factory(make_env("base"))
+    assert _emitted(parse(base, _snippet("primary", option=":not:")))
+    idfprod = app_factory(
+        make_env("idfprod", hidden_services=["times-square"])
+    )
+    assert not _emitted(parse(idfprod, _snippet("primary", option=":not:")))
+
+
+def test_unknown_token_warns_and_excludes(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """An unknown token warns and resolves to False (excluding the body)."""
+    app = app_factory(make_env("base"))
+    doctree = parse(app, _snippet("bogus"))
+    assert not _emitted(doctree)
+    assert "unknown-condition" in app.warning.getvalue()
+
+
+def test_unknown_token_warning_is_suppressible(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """suppress_warnings silences the unknown-condition warning."""
+    app = app_factory(
+        make_env("base"),
+        confoverrides={"suppress_warnings": ["rspdocs.unknown-condition"]},
+    )
+    parse(app, _snippet("bogus"))
+    assert app.warning.getvalue() == ""

--- a/tests/sphinxext/test_roles.py
+++ b/tests/sphinxext/test_roles.py
@@ -1,0 +1,87 @@
+"""Doctree tests for the :rsp-url: and :rsp-link: roles."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from docutils import nodes
+from sphinx.testing.restructuredtext import parse
+from sphinx.testing.util import SphinxTestApp
+
+from rspdocs.discovery.models import PhalanxEnv
+
+MakeEnv = Callable[..., PhalanxEnv]
+AppFactory = Callable[..., SphinxTestApp]
+
+
+def test_rsp_url_emits_literal(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """``:rsp-url:`service``` renders the URL as a code literal."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-url:`tap`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "https://data.lsst.cloud/api/tap/"
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_link_default_text_is_url(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """With no explicit title, the link text is the URL itself."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-link:`rsp`")
+    ref = doctree.next_node(nodes.reference)
+    assert isinstance(ref, nodes.reference)
+    assert ref["refuri"] == "https://data.lsst.cloud/"
+    assert ref.astext() == "https://data.lsst.cloud/"
+    assert ref.get("internal") is False
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_link_explicit_title(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """``:rsp-link:`Title <service>``` uses Title as the link text."""
+    app = app_factory(make_env("idfint"))  # times-square deployed here
+    doctree = parse(app, ":rsp-link:`Times Square <times-square>`")
+    ref = doctree.next_node(nodes.reference)
+    assert isinstance(ref, nodes.reference)
+    assert ref.astext() == "Times Square"
+    assert ref["refuri"].endswith("/times-square/")
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_url_unknown_service_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """An unknown service token warns and falls back to a literal token."""
+    app = app_factory(make_env("base"))
+    doctree = parse(app, ":rsp-url:`bogus`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "bogus"
+    assert "unknown-service" in app.warning.getvalue()
+
+
+def test_rsp_link_unavailable_service_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A known-but-absent service warns and emits no broken empty link."""
+    app = app_factory(make_env("base"))  # base has no tap
+    doctree = parse(app, ":rsp-link:`tap`")
+    assert doctree.next_node(nodes.reference) is None
+    assert "unavailable-service" in app.warning.getvalue()
+
+
+def test_role_warning_is_suppressible(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """suppress_warnings silences the rspdocs warning family."""
+    app = app_factory(
+        make_env("base"),
+        confoverrides={"suppress_warnings": ["rspdocs.unavailable-service"]},
+    )
+    parse(app, ":rsp-link:`tap`")
+    assert app.warning.getvalue() == ""

--- a/tests/sphinxext/test_services.py
+++ b/tests/sphinxext/test_services.py
@@ -1,0 +1,82 @@
+"""Unit tests for the sphinxext service registry and condition resolver."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from rspdocs.discovery.models import PhalanxEnv
+from rspdocs.sphinxext.services import (
+    is_available,
+    is_known_service,
+    resolve_condition,
+    resolve_url,
+)
+
+MakeEnv = Callable[..., PhalanxEnv]
+
+
+def test_is_known_service() -> None:
+    """Service tokens (and their aliases) are recognized; env names aren't."""
+    assert is_known_service("rsp")
+    assert is_known_service("squareone")
+    assert is_known_service("times-square")
+    assert not is_known_service("bogus")
+    assert not is_known_service("idfprod")  # an env name, not a service
+    assert not is_known_service("primary")  # a condition keyword
+
+
+def test_resolve_url_present(make_env: MakeEnv) -> None:
+    """A deployed service resolves to its exact URL string."""
+    env = make_env("idfprod", hidden_services=["times-square"])
+    assert resolve_url(env, "rsp") == "https://data.lsst.cloud/"
+    assert resolve_url(env, "tap") == "https://data.lsst.cloud/api/tap/"
+    # Aliases resolve to the same attribute.
+    assert resolve_url(env, "squareone") == resolve_url(env, "rsp")
+    assert resolve_url(env, "nb") == resolve_url(env, "nublado")
+
+
+def test_resolve_url_absent(make_env: MakeEnv) -> None:
+    """Unknown, undeployed, and hidden services all resolve to None."""
+    base = make_env("base")
+    assert resolve_url(base, "tap") is None  # base has no datasets
+    assert resolve_url(base, "bogus") is None  # unknown service token
+    idfprod = make_env("idfprod", hidden_services=["times-square"])
+    assert resolve_url(idfprod, "times-square") is None  # hidden in shim
+
+
+def test_is_available(make_env: MakeEnv) -> None:
+    """Availability tracks the presence of a resolved URL."""
+    idfprod = make_env("idfprod", hidden_services=["times-square"])
+    base = make_env("base")
+    idfint = make_env("idfint")
+    assert is_available(idfprod, "tap")
+    assert not is_available(base, "tap")
+    assert not is_available(idfprod, "times-square")  # hidden
+    assert is_available(idfint, "times-square")  # staff env shows it
+
+
+def test_resolve_condition_primary(make_env: MakeEnv) -> None:
+    """The ``primary`` keyword resolves via PhalanxEnv.is_primary."""
+    idfprod = make_env("idfprod", hidden_services=["times-square"])
+    assert resolve_condition(idfprod, "primary") is True
+    assert resolve_condition(make_env("base"), "primary") is False
+
+
+def test_resolve_condition_env_name(make_env: MakeEnv) -> None:
+    """An environment-name token matches only that environment."""
+    base = make_env("base")
+    assert resolve_condition(base, "base") is True
+    assert resolve_condition(base, "idfprod") is False
+
+
+def test_resolve_condition_service(make_env: MakeEnv) -> None:
+    """A service token resolves to that service's availability."""
+    idfprod = make_env("idfprod", hidden_services=["times-square"])
+    base = make_env("base")
+    assert resolve_condition(idfprod, "tap") is True
+    assert resolve_condition(base, "tap") is False
+
+
+def test_resolve_condition_unknown(make_env: MakeEnv) -> None:
+    """A token that is neither service, env, nor ``primary`` returns None."""
+    assert resolve_condition(make_env("base"), "bogus") is None


### PR DESCRIPTION
## Summary

- Add the in-repo `rspdocs.sphinxext` extension with two roles and a conditional directive resolved from Repertoire discovery data at parse time: `:rsp-url:` (URL as a code literal), `:rsp-link:` (a linkchecked hyperlink, with `title <target>` support), and `.. rsp-only::` (gates content on service / environment / `primary` tokens; AND by default, `:any:` for OR, `:not:` to negate).
- Excluded `rsp-only` content is dropped at parse time, so it never leaks into the ToC, index, or search. The discovery content hash is a config value with `rebuild="env"` so data changes invalidate cached doctrees; unknown/unavailable services warn with a precise `file:line`, fatal under `-W` and suppressible via `suppress_warnings`.
- Migrate the URL/link substitutions to the roles, convert the three `jinja` include-wrappers to `rsp-only`, prune the retired substitutions from `rst_epilog.rst.jinja`, and rewrite the contributing guide around roles → substitutions → `rsp-only` → jinja. Adds unit + doctree tests under `tests/sphinxext`.

## Validation steps

- Build the primary environment and confirm no `rspdocs.*` warnings: `tox -e sphinx-idfprod` (uses `-n -W`).
- Build a service-lacking environment to exercise `rsp-only` exclusion and the `:not:` branches: `tox -e sphinx-summit` and `tox -e sphinx-base`.
- Spot-check rendered HTML: a migrated `:rsp-link:` matches the prior `|…|` output, and an `.. rsp-only:: primary` / `:not:` page renders the primary branch for `idfprod` vs. the non-primary branch for a staff env.
- Confirm `:rsp-link:` targets are crawled: `tox -e linkcheck-idfprod`.
- Incremental-build check: change a cached `_build/discovery/{env}.json` URL and rebuild without `make clean`; the doctree should re-bake the new URL.

## References

- Closes #85
- Jira: https://rubinobs.atlassian.net/browse/DM-55245