### PR TITLE
DM-55245: Migrate hard-coded environment URLs to templated constructs

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -41,6 +41,12 @@ rsp_env: Optional[PhalanxEnv] = env_service.envs[target_env]
 # ``extensions``; don't also invoke it from the setup() below.
 extensions.append("rspdocs.sphinxext")  # noqa: F405
 
+# Enable |substitutions| inside code-block/literalinclude directives that carry
+# the :substitutions: option, so code samples can embed environment URLs (e.g.
+# the TAP URL in the notebooks FAQ). The substitutions themselves are defined
+# in rst_prolog below.
+extensions.append("sphinx_substitution_extensions")  # noqa: F405
+
 # Data channels the extension resolves roles/conditions against.
 rsp_all_envs = env_service.envs
 
@@ -61,7 +67,11 @@ _config_template_loader = FileSystemLoader(".")
 _jinja_env = Environment(
     loader=_config_template_loader, autoescape=select_autoescape()
 )
-rst_epilog = _jinja_env.get_template("rst_epilog.rst.jinja").render(
+# The substitutions and link targets are rendered into rst_prolog rather than
+# rst_epilog because sphinx-substitution-extensions resolves |substitutions|
+# inside code blocks at parse time: the definitions must already have been
+# parsed when the directive runs, so they have to precede the page content.
+rst_prolog = _jinja_env.get_template("rst_prolog.rst.jinja").render(
     env=rsp_env
 )
 

--- a/docs/contributing/env-specific-docs.rst
+++ b/docs/contributing/env-specific-docs.rst
@@ -100,14 +100,28 @@ These substitutions are defined in :file:`rst_prolog.rst.jinja`, which is itself
 
    * - Syntax
      - Example
+     - Description
    * - ``|rsp-at|``
      - |rsp-at|
+     - An inline link to this environment's homepage; outside the primary environment it also names the environment.
    * - ``|rsp-env|``
      - |rsp-env|
+     - The environment's full display name, as plain text.
    * - ``|rsp-env-link|``
      - |rsp-env-link|
+     - The environment's full display name, linked to its homepage.
+   * - ``|rsp-tap-url|``
+     - .. rsp-only:: tap
+
+          |rsp-tap-url|
+     - The TAP service's URL without a trailing slash, for :ref:`code samples <envdocs-code-substitutions>`.
+       Defined only in environments with a TAP service.
    * - ``|webdav-server|``
-     - |webdav-server|
+     - .. rsp-only:: webdav
+
+          |webdav-server|
+     - The WebDAV server address with a username placeholder, for :ref:`code samples <envdocs-code-substitutions>`.
+       Defined only in environments with a WebDAV service.
 
 Prefer a :ref:`role <envdocs-roles>` whenever you only need a service's URL, a link to it, or a URL derived by appending a path — the roles replaced the per-service URL, link, and derived-path substitutions the docs used to define.
 

--- a/docs/contributing/env-specific-docs.rst
+++ b/docs/contributing/env-specific-docs.rst
@@ -17,6 +17,7 @@ Reach for them in this order, from the most targeted to the most general:
 
 - :ref:`envdocs-roles` for inline URLs and links to RSP services.
 - :ref:`envdocs-substitutions` for env-specific words and short phrases that a role can't produce.
+- :ref:`envdocs-code-substitutions` for environment URLs inside code samples (``code-block`` and ``literalinclude``).
 - :ref:`envdocs-conditional` to include or exclude whole blocks of content per environment.
 - :ref:`envdocs-jinja` when a branch's text must be *computed* from environment data (interpolation, loops, or expressions).
 - :ref:`envdocs-jinja-includes` to swap large included files.
@@ -42,6 +43,12 @@ Each takes a service name — listed in the table below — and resolves it to t
     For example, ``:rsp-link:`rsp``` renders as :rsp-link:`rsp`.
 
     Give an explicit link title with the familiar ``title <target>`` syntax: ``:rsp-link:`Rubin Science Platform <rsp>``` renders as :rsp-link:`Rubin Science Platform <rsp>`.
+
+Both roles also accept a path after the service name, appended to the service's URL for the environment being built.
+For example, ``:rsp-url:`rsp/settings/quotas``` renders as :rsp-url:`rsp/settings/quotas`, and ``:rsp-link:`Quotas page <rsp/settings/quotas>``` renders as :rsp-link:`Quotas page <rsp/settings/quotas>`.
+The path is always joined relative to the service's full URL (which may itself include a path — ``portal/onlinehelp/`` resolves under ``/portal/app/``), and slashes at the seam are normalized, so you don't need to worry about whether the path takes a leading slash: ``rsp/settings`` and ``rsp//settings`` are equivalent.
+The trailing slash of the result follows the path exactly as you write it, since some endpoints are sensitive to it.
+Note that only the service token is validated — a typo in the path builds without complaint, so check that the resulting URL exists.
 
 Some services aren't deployed in every environment; targeting a service that is absent in the environment being built raises a warning (fatal under ``-W``), which usually means the reference should be wrapped in a matching :ref:`rsp-only <envdocs-conditional>` block.
 
@@ -84,8 +91,9 @@ Some services aren't deployed in every environment; targeting a service that is 
 Using reStructuredText substitutions
 ====================================
 
-For env-specific *prose* — a word, a name, or a derived path that a role can't produce — use `reStructuredText substitutions <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#substitutions>`__.
-These substitutions are defined in :file:`rst_epilog.rst.jinja`, which is itself templated with Jinja so the replacement text can vary by environment.
+For env-specific *prose* — a word, a name, or a phrase that a role can't produce — use `reStructuredText substitutions <https://www.sphinx-doc.org/en/master/usage/restructuredtext/basics.html#substitutions>`__.
+These substitutions are defined in :file:`rst_prolog.rst.jinja`, which is itself templated with Jinja so the replacement text can vary by environment.
+(The definitions are rendered into Sphinx's ``rst_prolog``, not ``rst_epilog``, so they precede every page's content and are therefore also available to :ref:`code samples <envdocs-code-substitutions>`.)
 
 .. list-table:: Available substitutions
    :header-rows: 1
@@ -98,14 +106,37 @@ These substitutions are defined in :file:`rst_epilog.rst.jinja`, which is itself
      - |rsp-env|
    * - ``|rsp-env-link|``
      - |rsp-env-link|
-   * - ``|rsp-quotas-url|``
-     - |rsp-quotas-url|
-   * - ``|rsp-quotas-page|``
-     - |rsp-quotas-page|
    * - ``|webdav-server|``
      - |webdav-server|
 
-Prefer a :ref:`role <envdocs-roles>` whenever you only need a service's URL or a link to it — the roles replaced the per-service URL and link substitutions the docs used to define.
+Prefer a :ref:`role <envdocs-roles>` whenever you only need a service's URL, a link to it, or a URL derived by appending a path — the roles replaced the per-service URL, link, and derived-path substitutions the docs used to define.
+
+.. _envdocs-code-substitutions:
+
+Substitutions inside code samples
+=================================
+
+Roles and ordinary substitution references don't work inside literal blocks, so environment URLs in code samples need one more ingredient: the `sphinx-substitution-extensions <https://pypi.org/project/Sphinx-Substitution-Extensions/>`__ package, which is enabled in this build.
+Add the ``:substitutions:`` option to a ``code-block`` (or ``:content-substitutions:`` to a ``literalinclude``) and any ``|substitution|`` in its content is replaced with the plain text of its definition:
+
+.. code-block:: rst
+
+   .. code-block:: bash
+      :substitutions:
+
+      export EXTERNAL_TAP_URL="|rsp-tap-url|"
+
+``|rsp-tap-url|`` is the TAP service's URL without a trailing slash, the form client configuration expects (whereas ``:rsp-url:`tap``` renders discovery's canonical trailing-slash URL).
+It is defined only in environments that have a TAP service, so wrap its uses in a matching ``.. rsp-only:: tap`` block — as in this rendered example:
+
+.. rsp-only:: tap
+
+   .. code-block:: bash
+      :substitutions:
+
+      export EXTERNAL_TAP_URL="|rsp-tap-url|"
+
+Because the substitution machinery matches text at parse time, only substitutions defined in :file:`rst_prolog.rst.jinja` (or earlier in the same page) are available inside code samples.
 
 .. _envdocs-conditional:
 

--- a/docs/contributing/env-specific-docs.rst
+++ b/docs/contributing/env-specific-docs.rst
@@ -127,9 +127,11 @@ Add the ``:substitutions:`` option to a ``code-block`` (or ``:content-substituti
       export EXTERNAL_TAP_URL="|rsp-tap-url|"
 
 ``|rsp-tap-url|`` is the TAP service's URL without a trailing slash, the form client configuration expects (whereas ``:rsp-url:`tap``` renders discovery's canonical trailing-slash URL).
-It is defined only in environments that have a TAP service, so wrap its uses in a matching ``.. rsp-only:: tap`` block — as in this rendered example:
+It is defined only in environments that have a TAP service, so wrap its uses in a matching ``.. rsp-only:: tap`` block — including any lead-in prose that would be left dangling in environments where the block is dropped.
 
 .. rsp-only:: tap
+
+   In this environment, the example above renders as:
 
    .. code-block:: bash
       :substitutions:

--- a/docs/guides/auth/groups.rst
+++ b/docs/guides/auth/groups.rst
@@ -79,7 +79,7 @@ some are generic processes for manipulating directory permissions in Unix-like o
 
 Instructions for creating and sharing a directory with a group:
 
-* In a browser, navigate to `data.lsst.cloud <https://data.lsst.cloud>`_ and log in to the Notebook Aspect.
+* In a browser, navigate to :rsp-link:`rsp` and log in to the Notebook Aspect.
 
 * Open a terminal, navigate to ``/home``, and modify the permissions on your home directory to let others access any shared directories within it (see your own username with ``whoami``).
 

--- a/docs/guides/getting-started/user-step-by-step.primary.in.rst
+++ b/docs/guides/getting-started/user-step-by-step.primary.in.rst
@@ -20,7 +20,7 @@ Before getting started
    - You *must* have an account with one of the supported institutions or organizations to use the RSP.
    - **It is highly recommended to link a non-institutional account** (e.g., GitHub, ORCID; see step 10, below) to ensure continuous access if you move institutions.
 
-3. Review the `Acceptable Use Policy <https://data.lsst.cloud/terms>`__ (AUP).
+3. Review the :rsp-link:`Acceptable Use Policy <rsp/terms>` (AUP).
 
    - Access to the RSP is contingent on abiding by the AUP.
 

--- a/docs/guides/hybrid.md
+++ b/docs/guides/hybrid.md
@@ -1,5 +1,10 @@
 # Hybrid model
 
+% Intentionally environment-specific: this page describes the hybrid
+% Google Cloud + USDF architecture of the flagship RSP at data.lsst.cloud,
+% so its data.lsst.cloud URLs are deliberate and must not be templated
+% (see https://github.com/lsst/rsp_lsst_io/issues/87).
+
 The flagship Rubin Science Platform (RSP) at [data.lsst.cloud](https://data.lsst.cloud) is a hybrid deployment, with services and data distributed across multiple data centers:
 
 - Most of the services and some data are hosted on the Google Cloud Platform.

--- a/docs/guides/life/quotas.rst
+++ b/docs/guides/life/quotas.rst
@@ -15,14 +15,14 @@ For information on other available resources beyond the RSP, including additiona
 .. important::
    The Rubin Science Platform is currently in preview mode, and its capabilities are expected to evolve for the duration of the Survey. The nature and amount of these resources are also expected to evolve (mostly upwards) for the duration of the survey.
 
-   During times of peak demand, some of these limits may be lowered temporarily to maintain availability. Always consult your |rsp-quotas-page| (found under your account settings or directly at |rsp-quotas-url| ) for limits being currently applied — that page is a live view of the system.
+   During times of peak demand, some of these limits may be lowered temporarily to maintain availability. Always consult your :rsp-link:`Quotas page <rsp/settings/quotas>` (found under your account settings or directly at :rsp-url:`rsp/settings/quotas` ) for limits being currently applied — that page is a live view of the system.
 
 If you are a heavy user of the RSP APIs, make sure to read the relevant section below.
 
 The Quotas page
 ===============
 
-You can find your |rsp-quotas-page| under your user profile, accessible through the :rsp-link:`rsp` home page:
+You can find your :rsp-link:`Quotas page <rsp/settings/quotas>` under your user profile, accessible through the :rsp-link:`rsp` home page:
 
 .. figure:: quotas_ani.gif
    :alt: animation for how to navigate to the Quotas page
@@ -43,7 +43,7 @@ Notebooks
 ---------
 
 When you access the Notebooks capability, your JupyterLab session is allocated its own container in which anything you do (run notebooks, run code from the JupyterLab terminal) executes.
-Your |rsp-quotas-page| shows the memory size and number of cores for the largest instance of container you can ask the Notebook service for.
+Your :rsp-link:`Quotas page <rsp/settings/quotas>` shows the memory size and number of cores for the largest instance of container you can ask the Notebook service for.
 
 .. important::
    Exhausting your allocated memory can cause your container to die.
@@ -55,7 +55,7 @@ APIs
 ----
 
 .. note::
-   At the current time, the service names shown in your |rsp-quotas-page| page are our internal engineering names for the various services.
+   At the current time, the service names shown in your :rsp-link:`Quotas page <rsp/settings/quotas>` are our internal engineering names for the various services.
    This will be fixed soon.
 
 This section describes current types of API limits.
@@ -67,7 +67,7 @@ Rate limits
 
 Most APIs are rate-limited with a cap on requests over a 1-minute period.
 These are listed under the "Rate limits" sub-section.
-Your |rsp-quotas-page| shows you how many requests you can make in 60 seconds before a given service starts refusing your requests.
+Your :rsp-link:`Quotas page <rsp/settings/quotas>` shows you how many requests you can make in 60 seconds before a given service starts refusing your requests.
 Once that happens, 60 seconds have to pass before the counter resets.
 
 Concurrent queries

--- a/docs/guides/notebooks/faq/index.rst
+++ b/docs/guides/notebooks/faq/index.rst
@@ -48,25 +48,28 @@ Yes, it is possible to install ``lsst.rsp`` on one's own computer and run it loc
 
 Note that accessing data that are hosted at the IDF will additionally require a security token. See this documentation here: https://nb.lsst.io/environment/tokens.html for how to get a security token.
 
-As an example, we will walk through how to access the Rubin LSST TAP service locally.
+.. rsp-only:: tap
 
-After getting an access token, set the value of the environment variable ``ACCESS_TOKEN`` to the path to the token.
+   As an example, we will walk through how to access the Rubin LSST TAP service locally.
 
-Then set the TAP URL endpoint ``EXTERNAL_TAP_URL`` to ``"https://data.lsst.cloud/api/tap"`` (e.g. for macOS, execute the following)
+   After getting an access token, set the value of the environment variable ``ACCESS_TOKEN`` to the path to the token.
 
-.. code-block:: bash
+   Then set the TAP URL endpoint ``EXTERNAL_TAP_URL`` to |rsp-tap-url| (e.g. for macOS, execute the following)
 
-   export EXTERNAL_TAP_URL="https://data.lsst.cloud/api/tap"
+   .. code-block:: bash
+      :substitutions:
 
-In a python shell or notebook environment, it should then be possible to execute the following:
+      export EXTERNAL_TAP_URL="|rsp-tap-url|"
 
-.. code-block:: bash
+   In a python shell or notebook environment, it should then be possible to execute the following:
 
-   from lsst.rsp import get_tap_service, retrieve_query
-   service = get_tap_service()
-   query = "SELECT * FROM tap_schema.schemas"
-   results = service.search(query).to_table()
-   print(results)
+   .. code-block:: bash
+
+      from lsst.rsp import get_tap_service, retrieve_query
+      service = get_tap_service()
+      query = "SELECT * FROM tap_schema.schemas"
+      results = service.search(query).to_table()
+      print(results)
 
 
 *Although the LSST environment can be run locally, we strongly recommend to use it in the RSP environment.*

--- a/docs/guides/notebooks/starting-and-stopping/index.rst
+++ b/docs/guides/notebooks/starting-and-stopping/index.rst
@@ -2,7 +2,7 @@
 Start and stop a server
 #######################
 
-From the RSP landing page at `data.lsst.cloud <https://data.lsst.cloud/>`_ click on the central panel for Notebooks.
+From the RSP landing page at :rsp-link:`rsp` click on the central panel for Notebooks.
 
 Select software version and server size
 ---------------------------------------

--- a/docs/guides/portal/starting-and-stopping/index.rst
+++ b/docs/guides/portal/starting-and-stopping/index.rst
@@ -5,7 +5,7 @@ Start and stop a session
 Start a Portal session
 ----------------------
 
-From the RSP landing page at `data.lsst.cloud <https://data.lsst.cloud/>`_ click on the left panel for the Portal.
+From the RSP landing page at :rsp-link:`rsp` click on the left panel for the Portal.
 
 From the main landing page (see the figure below), click on any tab to go to the graphical user interface for querying data.
 

--- a/docs/guides/portal/using-the-portal/index.rst
+++ b/docs/guides/portal/using-the-portal/index.rst
@@ -51,7 +51,7 @@ To interact with data, click on one of the tabs that are displayed across the to
 * **Multi-archive TAP**: execute ADQL queries to retrieve catalogs from external (non-Rubin) TAP tables.
 * **Upload**: upload your own tables, which can then be joined with Rubin catalogs.
 * **Job Monitor**: check the status of your executed queries, see the actual query and information about the results (for completed queries).
-* **Results**: see the catalogs and/or images resulting from your executed queries, and interact with them. The image viewer and interactive plotting tools are based on `Firefly <https://data-int.lsst.cloud/portal/app/onlinehelp/>`_, which is built by `IPAC <https://www.ipac.caltech.edu/>`_.
+* **Results**: see the catalogs and/or images resulting from your executed queries, and interact with them. The image viewer and interactive plotting tools are based on :rsp-link:`Firefly <portal/onlinehelp/>`, which is built by `IPAC <https://www.ipac.caltech.edu/>`_.
 
 
 

--- a/docs/guides/times-square/github-repos/installation-howto.rst
+++ b/docs/guides/times-square/github-repos/installation-howto.rst
@@ -74,6 +74,10 @@ For Times Square to access your repository (even if its a public repository), yo
 
 These are the Times Square GitHub Apps for each available environment:
 
+.. Intentionally environment-specific: this table enumerates every
+   environment that runs Times Square, so its hostnames must stay hard-coded
+   (see https://github.com/lsst/rsp_lsst_io/issues/87).
+
 .. list-table::
    :header-rows: 1
 
@@ -83,7 +87,7 @@ These are the Times Square GitHub Apps for each available environment:
      - `Times Square (USDF) <https://github.com/apps/times-square-usdf>`__
    * - usdf-rsp-dev.slac.stanford.edu
      - `Times Square (usdf-rsp-dev) <https://github.com/apps/times-square-usdf-rsp-dev>`__
-   * - data-dev.slac.stanford.edu
+   * - data-dev.lsst.cloud
      - `Times Square (data-dev.lsst.cloud) <https://github.com/apps/times-square-data-dev-lsst-cloud>`__
 
 From the GitHub App's page, click the :guilabel:`Install` button.

--- a/docs/updates/index.rst
+++ b/docs/updates/index.rst
@@ -34,7 +34,7 @@ Updates
    The default, ``cutout-sync``, now returns smaller-sized files that contain only the data that the majority of cutout service users want, and improves performance for everyone.
 
    **Settings user interface (UI)**:
-   Accessed by clicking on your username in the ``data.lsst.cloud`` landing page, the Settings UI now contains four subpages: `Account <https://data.lsst.cloud/settings>`_, `Access tokens <https://data.lsst.cloud/settings/tokens>`_, `Quotas <https://data.lsst.cloud/settings/quotas>`_, and `Sessions <https://data.lsst.cloud/settings/sessions>`_.
+   Accessed by clicking on your username in the ``{{ env.domain }}`` landing page, the Settings UI now contains four subpages: :rsp-link:`Account <rsp/settings>`, :rsp-link:`Access tokens <rsp/settings/tokens>`, :rsp-link:`Quotas <rsp/settings/quotas>`, and :rsp-link:`Sessions <rsp/settings/sessions>`.
 
    **Quota increases**:
    The disk storage quota was increased from 35 to 40 GB.
@@ -116,7 +116,7 @@ Updates
 
    {% else %}
 
-   This page is kept updated for the RSP at ``data.lsst.cloud`` only.
-   Use the drop-down menu at upper right to switch from the |rsp-at| to ``data.lsst.cloud``.
+   This page is kept updated for the RSP at ``{{ all_envs.primary.domain }}`` only.
+   Use the drop-down menu at upper right to switch from the |rsp-at| to ``{{ all_envs.primary.domain }}``.
 
    {% endif %}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "Jinja2",
     "PyYAML",
     "sphinx-jinja",
+    "Sphinx-Substitution-Extensions",
     "sphinxcontrib-youtube",
 ]
 dynamic = ["version"]

--- a/rst_prolog.rst.jinja
+++ b/rst_prolog.rst.jinja
@@ -1,12 +1,17 @@
 .. Templated substitutions ====================================================
 ..
-.. Inline URLs and links are provided by the :rsp-url: and :rsp-link: roles
-.. from the rspdocs.sphinxext extension; these substitutions cover only the
-.. env-specific *prose* and derived paths those roles can't produce. See
-.. docs/contributing/env-specific-docs.rst.
+.. Inline URLs and links -- including URLs with appended paths, like
+.. :rsp-url:`rsp/settings/quotas` -- are provided by the :rsp-url: and
+.. :rsp-link: roles from the rspdocs.sphinxext extension; these substitutions
+.. cover only the env-specific *prose* and code-sample values those roles
+.. can't produce. See docs/contributing/env-specific-docs.rst.
+..
+.. This file is rendered into rst_prolog (not rst_epilog) so the definitions
+.. are parsed before any directive in a page: sphinx-substitution-extensions
+.. resolves |name| inside code-block/literalinclude directives marked with
+.. :substitutions: at parse time, which only finds definitions that precede
+.. the directive.
 
-.. |rsp-quotas-url| replace:: ``{{ env.squareone_url}}settings/quotas``
-.. |rsp-quotas-page| replace:: `Quotas page <{{ env.squareone_url}}settings/quotas>`__
 {% if env.is_primary %}
 .. |rsp-at| replace:: `Rubin Science Platform <{{ env.squareone_url }}>`__
 {% else %}
@@ -14,6 +19,9 @@
 {% endif %}
 .. |rsp-env| replace:: {{ env.title_full }}
 .. |rsp-env-link| replace:: `{{ env.title_full }} <{{ env.squareone_url }}>`__
+{% if env.api_tap_url %}
+.. |rsp-tap-url| replace:: ``{{ (env.api_tap_url | string).rstrip("/") }}``
+{% endif %}
 {% if env.api_webdav_url %}
 .. |webdav-server| replace:: ``{{ env.api_webdav_url }}(your_username)``
 {% endif %}

--- a/src/rspdocs/sphinxext/__init__.py
+++ b/src/rspdocs/sphinxext/__init__.py
@@ -3,8 +3,10 @@ directive backed by Repertoire discovery data.
 
 The extension provides:
 
-* ``:rsp-url:`service``` -- a code literal of a service's URL,
-* ``:rsp-link:`service``` -- an external hyperlink to a service, and
+* ``:rsp-url:`service``` -- a code literal of a service's URL (optionally
+  with an appended path, as in ``:rsp-url:`rsp/settings```),
+* ``:rsp-link:`service``` -- an external hyperlink to a service (same
+  optional path syntax), and
 * ``.. rsp-only::`` -- content included only in matching environments.
 
 All three resolve against the `~rspdocs.discovery.models.PhalanxEnv` for the

--- a/src/rspdocs/sphinxext/roles.py
+++ b/src/rspdocs/sphinxext/roles.py
@@ -2,9 +2,13 @@
 
 ``:rsp-url:`service``` emits a code literal of the service's URL for the
 environment being built; ``:rsp-link:`service``` (or
-``:rsp-link:`Title <service>```) emits a real external hyperlink. Because both
-resolve at parse time, URLs can appear in code literals, tables, admonitions,
-and lists, and ``:rsp-link:`` references are crawled by ``linkcheck``.
+``:rsp-link:`Title <service>```) emits a real external hyperlink. A target may
+append a path to the service's URL, as in ``:rsp-url:`rsp/settings/quotas```
+or ``:rsp-link:`Firefly <portal/onlinehelp/>``` (see
+`~rspdocs.sphinxext.services.resolve_url` for the join rules). Because both
+roles resolve at parse time, URLs can appear in code literals, tables,
+admonitions, and lists, and ``:rsp-link:`` references are crawled by
+``linkcheck``.
 """
 
 from __future__ import annotations
@@ -13,44 +17,44 @@ from docutils import nodes
 from sphinx.util.docutils import ReferenceRole, SphinxRole
 
 from .logging import warn_unavailable_service, warn_unknown_service
-from .services import is_known_service, resolve_url
+from .services import is_known_service, resolve_url, split_service_path
 
 __all__ = ["RspUrlRole", "RspLinkRole"]
 
 
 class RspUrlRole(SphinxRole):
-    """``:rsp-url:`service``` -> a code literal of the service's URL."""
+    """``:rsp-url:`service[/path]``` -> a code literal of the URL."""
 
     def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
-        service = self.text
+        service, path = split_service_path(self.text)
         if not is_known_service(service):
             warn_unknown_service(service, location=self.get_location())
-            return [nodes.literal("", service)], []
+            return [nodes.literal("", self.text)], []
         env = self.config.rsp_env
-        url = resolve_url(env, service)
+        url = resolve_url(env, service, path=path)
         if url is None:
             warn_unavailable_service(
                 service, env.name, location=self.get_location()
             )
-            return [nodes.literal("", service)], []
+            return [nodes.literal("", self.text)], []
         return [nodes.literal("", url)], []
 
 
 class RspLinkRole(ReferenceRole):
-    """``:rsp-link:`service``` -> an external hyperlink to the service.
+    """``:rsp-link:`service[/path]``` -> an external hyperlink.
 
     With no explicit title the link text is the URL itself (matching the prior
-    ``|rsp-url|``/``|nb-url|`` substitutions); ``:rsp-link:`Title <service>```
-    uses ``Title`` as the link text.
+    ``|rsp-url|``/``|nb-url|`` substitutions);
+    ``:rsp-link:`Title <service[/path]>``` uses ``Title`` as the link text.
     """
 
     def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
-        service = self.target
+        service, path = split_service_path(self.target)
         if not is_known_service(service):
             warn_unknown_service(service, location=self.get_location())
             return [nodes.Text(self.title)], []
         env = self.config.rsp_env
-        url = resolve_url(env, service)
+        url = resolve_url(env, service, path=path)
         if url is None:
             warn_unavailable_service(
                 service, env.name, location=self.get_location()

--- a/src/rspdocs/sphinxext/services.py
+++ b/src/rspdocs/sphinxext/services.py
@@ -29,6 +29,7 @@ __all__ = [
     "SERVICE_PAGE_EXCLUDES",
     "KNOWN_ENVS",
     "is_known_service",
+    "split_service_path",
     "resolve_url",
     "is_available",
     "resolve_condition",
@@ -101,16 +102,42 @@ def is_known_service(name: str) -> bool:
     return name in SERVICE_ATTRS
 
 
-def resolve_url(env: PhalanxEnv, name: str) -> str | None:
+def split_service_path(target: str) -> tuple[str, str]:
+    """Split a role target into its service token and appended path.
+
+    The service token runs up to the first ``/``; everything after it is a
+    path for `resolve_url` to append to the service's URL. A target without a
+    ``/`` is a bare service token with an empty path. Service tokens must
+    therefore never contain a ``/``.
+    """
+    service, _, path = target.partition("/")
+    return service, path
+
+
+def resolve_url(env: PhalanxEnv, name: str, path: str = "") -> str | None:
     """Return the URL for service ``name`` in ``env``, or ``None``.
 
     ``None`` is returned both for an unknown service token and for a known
     service that is not deployed in this environment. Callers that need to
     distinguish the two should check `is_known_service` first.
+
+    A non-empty ``path`` is appended to the service's URL. The join always
+    treats ``path`` as relative to the full service URL (which may itself
+    carry a path, like the portal's ``/portal/app/``): slashes at the seam are
+    normalized away, so ``settings`` and ``/settings`` are equivalent. This is
+    deliberately not `~urllib.parse.urljoin`, whose RFC 3986 rules would
+    resolve a leading-slash path against the host root and drop the last
+    segment of a slashless base. The trailing slash of the result follows
+    ``path`` exactly as written.
     """
     attr = SERVICE_ATTRS.get(name)
     url = getattr(env, attr) if attr else None
-    return str(url) if url is not None else None
+    if url is None:
+        return None
+    base = str(url)
+    if not path:
+        return base
+    return f"{base.rstrip('/')}/{path.lstrip('/')}"
 
 
 def is_available(env: PhalanxEnv, name: str) -> bool:

--- a/tests/sphinxext/test_roles.py
+++ b/tests/sphinxext/test_roles.py
@@ -53,6 +53,53 @@ def test_rsp_link_explicit_title(
     assert app.warning.getvalue() == ""
 
 
+def test_rsp_url_with_path(make_env: MakeEnv, app_factory: AppFactory) -> None:
+    """``:rsp-url:`service/path``` appends the path to the service URL."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-url:`rsp/settings/quotas`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "https://data.lsst.cloud/settings/quotas"
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_link_with_path(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A titled link target may carry a path; extra slashes are normalized."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-link:`Account <rsp//settings>`")
+    ref = doctree.next_node(nodes.reference)
+    assert isinstance(ref, nodes.reference)
+    assert ref.astext() == "Account"
+    assert ref["refuri"] == "https://data.lsst.cloud/settings"
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_link_path_joins_service_url_path(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """The join is against the service's full URL, not the host root."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-link:`Firefly <portal/onlinehelp/>`")
+    ref = doctree.next_node(nodes.reference)
+    assert isinstance(ref, nodes.reference)
+    assert ref["refuri"].endswith("/portal/app/onlinehelp/")
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_url_unknown_service_with_path_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """An unknown service with a path warns and echoes the whole target."""
+    app = app_factory(make_env("base"))
+    doctree = parse(app, ":rsp-url:`bogus/settings`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "bogus/settings"
+    assert "unknown-service" in app.warning.getvalue()
+
+
 def test_rsp_url_unknown_service_warns(
     make_env: MakeEnv, app_factory: AppFactory
 ) -> None:

--- a/tests/sphinxext/test_services.py
+++ b/tests/sphinxext/test_services.py
@@ -12,6 +12,7 @@ from rspdocs.sphinxext.services import (
     is_known_service,
     resolve_condition,
     resolve_url,
+    split_service_path,
 )
 
 MakeEnv = Callable[..., PhalanxEnv]
@@ -35,6 +36,36 @@ def test_resolve_url_present(make_env: MakeEnv) -> None:
     # Aliases resolve to the same attribute.
     assert resolve_url(env, "squareone") == resolve_url(env, "rsp")
     assert resolve_url(env, "nb") == resolve_url(env, "nublado")
+
+
+def test_split_service_path() -> None:
+    """A target splits at the first slash into (service, path)."""
+    assert split_service_path("rsp") == ("rsp", "")
+    assert split_service_path("rsp/settings") == ("rsp", "settings")
+    assert split_service_path("rsp//settings") == ("rsp", "/settings")
+    assert split_service_path("portal/onlinehelp/") == (
+        "portal",
+        "onlinehelp/",
+    )
+    assert split_service_path("times-square") == ("times-square", "")
+
+
+def test_resolve_url_with_path(make_env: MakeEnv) -> None:
+    """An appended path joins relative to the service URL, slash-normalized."""
+    env = make_env("idfprod", hidden_services=["times-square"])
+    expected = "https://data.lsst.cloud/settings/quotas"
+    assert resolve_url(env, "rsp", path="settings/quotas") == expected
+    # A leading slash on the path is normalized away, not host-root-resolved.
+    assert resolve_url(env, "rsp", path="/settings/quotas") == expected
+    # The join is against the service's full URL, including its own path, and
+    # the trailing slash of the result follows the path as written.
+    assert resolve_url(env, "portal", path="onlinehelp/") == (
+        "https://data.lsst.cloud/portal/app/onlinehelp/"
+    )
+    # An empty path returns the service URL untouched.
+    assert resolve_url(env, "rsp", path="") == "https://data.lsst.cloud/"
+    # An absent service stays None regardless of path.
+    assert resolve_url(make_env("base"), "tap", path="x") is None
 
 
 def test_resolve_url_absent(make_env: MakeEnv) -> None:


### PR DESCRIPTION
## Summary

- Replaces the hard-coded `data.lsst.cloud` (and related) URLs found across the docs with environment-aware constructs, so every environment's edition renders its own URLs: `:rsp-url:`/`:rsp-link:` roles, prolog substitutions, and Jinja interpolation on the updates page.
- Adds [sphinx-substitution-extensions](https://pypi.org/project/Sphinx-Substitution-Extensions/) so substitutions resolve inside `code-block`/`literalinclude` (used for the `EXTERNAL_TAP_URL` example in the notebooks FAQ, now also gated by `rsp-only:: tap`). The templated definitions move from `rst_epilog` to `rst_prolog` because the extension resolves substitutions at parse time.
- Extends the `:rsp-url:`/`:rsp-link:` roles with path-append syntax (e.g. ``:rsp-link:`Account <rsp/settings>```): the path always joins relative to the service's URL with slash normalization, so authors never have to reason about leading/trailing slashes. This retired the per-page derived-URL substitutions (quotas, AUP) and made the Firefly online-help link per-environment.
- Annotates the two intentionally environment-specific sites (`hybrid.md`, the Times Square GitHub App table) and fixes the `data-dev` hostname typo in that table.

Review fixes:

- Guards the rendered `|rsp-tap-url|` example on the contributing page inside the `rsp-only:: tap` block, so TAP-less builds (base, summit, tucson-teststand) no longer end the paragraph with a dangling "as in this rendered example:" and no example.
- Fixes a doubled word on the quotas guide ("Quotas page page").
- Expands the substitutions table on the contributing page to document every available substitution — adding the previously undocumented `|rsp-tap-url|` and a description column noting each substitution's purpose and availability. The conditional substitutions' example cells are wrapped in `rsp-only` blocks so the table builds in environments where they're undefined (also fixing the latent fragility of the unguarded `|webdav-server|` example).
- The remaining hard-coded `id.lsst.cloud` identity URLs in `groups.rst` can't be templated until discovery carries a per-environment identity service URL — tracked in #96.

## Validation steps

- Build any two environments and compare, e.g. `tox run -e sphinx-idfprod` and `tox run -e sphinx-usdfprod`; check that the quotas guide, updates page, portal/notebook start-stop pages, and the notebooks FAQ TAP example each render that environment's own URLs.
- In the summit build (`tox run -e sphinx-summit`), confirm the notebooks FAQ no longer shows the external-TAP walkthrough and the updates page fallback names `data.lsst.cloud`.
- On the built contributing page (Writing environment-specific documentation), confirm the new "Substitutions inside code samples" section and the path-append role examples render with real URLs, and that the substitutions table lists all five substitutions with live examples; in the summit build, confirm that section omits the rendered example cleanly (no stranded lead-in sentence) and the table's `|rsp-tap-url|` example cell is empty.
- Check the Firefly link on the "Using the Portal" page points at the current environment's `/portal/app/onlinehelp/`.

## References

- Closes #87
- Follow-up: #96 (per-environment identity service URL for `groups.rst`)
- Jira: https://rubinobs.atlassian.net/browse/DM-55245
