### PR TITLE
DM-55245: Re-enable all 8 environment builds with serialized LTD uploads

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,14 +57,14 @@ jobs:
     strategy:
       matrix:
         rsp:
-          # - "base"
-          # - "idfdev"
-          # - "idfint"
+          - "base"
+          - "idfdev"
+          - "idfint"
           - "idfprod"
-          # - "summit"
-          # - "tucson-teststand"
-          # - "usdfdev"
-          # - "usdfprod"
+          - "summit"
+          - "tucson-teststand"
+          - "usdfdev"
+          - "usdfprod"
 
     steps:
       - uses: actions/checkout@v4
@@ -118,16 +118,25 @@ jobs:
     if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
 
     strategy:
+      # Serialize LTD uploads: only one environment uploads to LSST the Docs
+      # at a time. The builds themselves run in parallel in the `build` job;
+      # here we consume those artifacts one at a time so concurrent uploads
+      # can never race against each other. `max-parallel: 1` queues the matrix
+      # jobs sequentially within this workflow run without skipping or
+      # cancelling any of them. `fail-fast: false` ensures a failed upload for
+      # one environment does not cancel the pending uploads for the others.
+      fail-fast: false
+      max-parallel: 1
       matrix:
         rsp:
-          # - "base"
-          # - "idfdev"
-          # - "idfint"
+          - "base"
+          - "idfdev"
+          - "idfint"
           - "idfprod"
-          # - "summit"
-          # - "tucson-teststand"
-          # - "usdfdev"
-          # - "usdfprod"
+          - "summit"
+          - "tucson-teststand"
+          - "usdfdev"
+          - "usdfprod"
 
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
## Summary

- Re-enables the full 8-environment roster (`base`, `idfdev`, `idfint`, `idfprod`, `summit`, `tucson-teststand`, `usdfdev`, `usdfprod`) in the `build` and `upload-all` matrices of `ci.yaml`; previously only `idfprod` was active.
- Serializes LTD uploads with `max-parallel: 1` on the `upload-all` matrix so only one environment uploads to LSST the Docs at a time, addressing the publication bug suspected to stem from concurrent uploads. Builds themselves remain fully parallel. Job-level `concurrency` groups were deliberately avoided: matrix legs sharing a group cancel each other rather than queue.
- Adds `fail-fast: false` so one environment's failed upload doesn't cancel the remaining queued uploads.

Residual (out of scope): two merges to `main` landing within a few minutes of each other could still overlap uploads *across* workflow runs — a rare, pre-existing condition distinct from the within-run concurrency this PR fixes.

## Validation steps

- [ ] On this PR's CI run, confirm all 8 `build (env)` jobs succeed and the `upload-for-branch` preview publishes idfprod as before
- [ ] After merge to `main`, confirm the 8 `upload-all (env)` jobs run strictly one at a time (each starts only after the previous finishes)
- [ ] Confirm all editions publish: the main edition (idfprod) plus `/v/{env}/` editions for the other 7 environments
- [ ] Confirm the previously observed publication bug does not reproduce

## References

- Closes #88
- Jira: https://rubinobs.atlassian.net/browse/DM-55245