### PR TITLE
DM-55245: Add scheduled and on-demand site rebuilds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -18,6 +18,19 @@ env:
       - "*"
   pull_request: {}
   merge_group: {}
+  schedule:
+    # Weekly rebuild so the published sites pick up fresh Repertoire
+    # service-discovery data (fetched at build time) without needing a commit
+    # to land. Rubin deploys on Patch Thursdays in US Pacific time; this fires
+    # at 07:00 UTC Friday, which is Thursday 23:00 PST / Friday 00:00 PDT
+    # Pacific — after the Thursday deployment window has settled. Scheduled
+    # events always run on the default branch (main), so the upload-all job's
+    # refs/heads/main guard is satisfied.
+    - cron: "0 7 * * 5"
+  # On-demand rebuild. When dispatched on the main ref this runs the full
+  # build + serialized LTD upload path (see the upload-all job's condition);
+  # dispatched on any other ref it builds but does not publish.
+  workflow_dispatch: {}
 
 jobs:
   lint:
@@ -111,11 +124,15 @@ jobs:
           username: ${{ secrets.LTD_USERNAME }}
           password: ${{ secrets.LTD_PASSWORD }}
 
-  # For merges to main, run an upload for all environments
+  # For merges to main — and scheduled or manually dispatched rebuilds on the
+  # main ref — run an upload for all environments. The refs/heads/main guard
+  # is required: `schedule` always runs on the default branch (so it passes),
+  # but `workflow_dispatch` can be invoked on any branch, and we must not
+  # publish from a ticket branch.
   upload-all:
     runs-on: ubuntu-latest
     needs: [build]
-    if: ${{ (github.event_name == 'push') && (github.ref == 'refs/heads/main') }}
+    if: ${{ (github.event_name == 'push' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && (github.ref == 'refs/heads/main') }}
 
     strategy:
       # Serialize LTD uploads: only one environment uploads to LSST the Docs
@@ -168,3 +185,13 @@ jobs:
         run: |
           pip install ltd-conveyor
           ltd upload --dir _build/html/${{ matrix.rsp }} --product rsp --git-ref ${{ matrix.rsp }}
+
+      - name: Report status
+        if: always()
+        uses: ravsamhq/notify-slack-action@v2
+        with:
+          status: ${{ job.status }}
+          notify_when: "failure"
+          notification_title: "LTD upload for `${{ matrix.rsp }}` in {repo} failed"
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,12 +21,13 @@ env:
   schedule:
     # Weekly rebuild so the published sites pick up fresh Repertoire
     # service-discovery data (fetched at build time) without needing a commit
-    # to land. Rubin deploys on Patch Thursdays in US Pacific time; this fires
-    # at 07:00 UTC Friday, which is Thursday 23:00 PST / Friday 00:00 PDT
-    # Pacific — after the Thursday deployment window has settled. Scheduled
-    # events always run on the default branch (main), so the upload-all job's
-    # refs/heads/main guard is satisfied.
-    - cron: "0 7 * * 5"
+    # to land. Rubin deploys on Patch Thursdays, with all updates in place by
+    # 3:15 pm US Pacific. GitHub cron is UTC-only, so 23:15 UTC Thursday is
+    # 3:15 pm PST (winter) and 4:15 pm PDT (summer) — never earlier than the
+    # end of the update window in either season. Scheduled events always run
+    # on the default branch (main), so the upload-all job's refs/heads/main
+    # guard is satisfied.
+    - cron: "15 23 * * 4"
   # On-demand rebuild. When dispatched on the main ref this runs the full
   # build + serialized LTD upload path (see the upload-all job's condition);
   # dispatched on any other ref it builds but does not publish.

--- a/docs/contributing/env-specific-docs.rst
+++ b/docs/contributing/env-specific-docs.rst
@@ -13,7 +13,7 @@ A small supplementary shim in the `documentation repository <https://github.com/
 When the network is unavailable, the build falls back to a local cache (in :file:`_build/discovery/`) and announces the fallback in the build output.
 
 Because discovery data is fetched fresh at build time, the published sites only pick up environment changes when a build runs.
-Merges to ``main`` trigger a build and publish, and a weekly scheduled rebuild (early Friday UTC, after the Thursday deployment window) republishes every environment so fresh discovery data flows out without needing a commit.
+Merges to ``main`` trigger a build and publish, and a weekly scheduled rebuild (Thursday 23:15 UTC, after the Patch Thursday update window ends at 3:15 pm Pacific) republishes every environment so fresh discovery data flows out without needing a commit.
 You can also trigger an on-demand rebuild by running the ``CI`` GitHub Actions workflow manually (its ``workflow_dispatch`` trigger); when dispatched from ``main`` it publishes all environments.
 
 This page describes the supported approaches for writing documentation that differs between environments.

--- a/docs/contributing/env-specific-docs.rst
+++ b/docs/contributing/env-specific-docs.rst
@@ -12,6 +12,10 @@ Information about the RSP environments is fetched at build time from the per-env
 A small supplementary shim in the `documentation repository <https://github.com/lsst/rsp_lsst_io>`_ (:file:`src/rspdocs/discovery/environments.json`) provides the handful of things discovery doesn't cover, such as human-readable environment titles and the roster of environments to build.
 When the network is unavailable, the build falls back to a local cache (in :file:`_build/discovery/`) and announces the fallback in the build output.
 
+Because discovery data is fetched fresh at build time, the published sites only pick up environment changes when a build runs.
+Merges to ``main`` trigger a build and publish, and a weekly scheduled rebuild (early Friday UTC, after the Thursday deployment window) republishes every environment so fresh discovery data flows out without needing a commit.
+You can also trigger an on-demand rebuild by running the ``CI`` GitHub Actions workflow manually (its ``workflow_dispatch`` trigger); when dispatched from ``main`` it publishes all environments.
+
 This page describes the supported approaches for writing documentation that differs between environments.
 Reach for them in this order, from the most targeted to the most general:
 


### PR DESCRIPTION
## Summary

- Adds a weekly `schedule` trigger to the CI workflow (`15 23 * * 4` — Thursdays 23:15 UTC, i.e. 3:15 pm PST / 4:15 pm PDT, at or after the end of the Patch Thursday update window (3:15 pm Pacific)) so the published sites pick up fresh Repertoire discovery data without requiring a commit.
- Adds a `workflow_dispatch` trigger for on-demand rebuilds. Scheduled runs and dispatches on `main` follow the exact same build + serialized LTD upload path (`upload-all` with `max-parallel: 1`, from #97); a dispatch on any other ref builds all environments but does not publish, and PR previews are unaffected.
- Adds a Slack failure notification (`ravsamhq/notify-slack-action@v2`, matching the `periodic-ci.yaml` pattern) to the `upload-all` job so a failed publish — scheduled or otherwise — is not silent.
- Documents the rebuild triggers in `docs/contributing/env-specific-docs.rst`.

Notes for reviewers:
- `periodic-ci.yaml` (Mondays 12:00 UTC, build + linkcheck, no upload) now conceptually overlaps with the weekly publish run; left untouched here, but could be narrowed or retired in a follow-up.
- The companion phalanx issue from #89's task list (add `applications/repertoire/values-*.yaml` to phalanx's docs path filter) is filed as lsst-sqre/phalanx#6711 and linked from #89.

## Validation steps

- [ ] After merge, manually run the `CI` workflow from `main` (workflow_dispatch) and confirm the 8 `upload-all` legs execute serially and all editions republish
- [ ] Confirm a dispatch from a ticket branch builds but skips `upload-all`
- [ ] After the first scheduled run (Thursday 23:15 UTC), confirm all editions republished with fresh discovery data
- [ ] Optionally force an upload failure scenario review: confirm the Slack alert wiring matches `periodic-ci.yaml` (`SLACK_ALERT_WEBHOOK` secret is available to this workflow)

## References

- Closes #89
- Jira: https://rubinobs.atlassian.net/browse/DM-55245