### PR TITLE
DM-55528: Add author skills: new-page and env-specific-content

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.claude/skills/env-specific-content/SKILL.md
+++ b/.claude/skills/env-specific-content/SKILL.md
@@ -1,0 +1,152 @@
+---
+name: env-specific-content
+description: Write rsp.lsst.io content that differs across RSP environments — rsp-url/rsp-link roles, the rsp-only directive, substitutions, .in.rst includes, and page excludes. Use whenever content mentions an environment URL or varies per environment.
+---
+
+# Environment-specific content
+
+rsp.lsst.io is built once per RSP environment (`base`, `idfdev`, `idfint`, `idfprod`, `summit`, `tucson-teststand`, `usdfdev`, `usdfprod`) from a single source tree, with `-W` so warnings are fatal.
+`idfprod` is the primary, public edition.
+Content that varies across environments must use the project's machinery — **never hard-code an environment hostname or URL**.
+
+This skill is a summary and decision guide.
+`docs/contributing/env-specific-docs.rst` is the full treatment (including the complete service-name table, code-sample substitutions, and the `jinja` directive) — **read it for anything beyond what's below.**
+
+## 1. Which mechanism to use
+
+Reach from the most targeted to the most general:
+
+| Situation | Mechanism |
+| --- | --- |
+| A URL or link to an RSP service | `rsp-url` / `rsp-link` role |
+| An env-specific word, name, or phrase a role can't produce | substitution (`\|rsp-env\|`, `\|rsp-at\|`, …) |
+| A paragraph or section shown only in some environments | `rsp-only` directive |
+| A large block of divergent content | `rsp-only` (or `jinja`) + an `*.in.rst` include |
+| A whole page absent from some environments | conditionalize the `toctree` entry **and** add the source to `page_excludes.yaml` |
+
+## 2. Usage examples (real patterns from this repo)
+
+### rsp-url / rsp-link roles
+
+Each role takes a service name (e.g. `rsp`, `portal`, `nublado`, `tap`, `webdav`, `times-square`) and resolves it for the environment being built.
+`rsp-url` renders the URL as a code literal; `rsp-link` renders a hyperlink.
+A path can be appended after the service name.
+
+From `docs/guides/portal/starting-and-stopping/index.rst`:
+
+```rst
+From the RSP landing page at :rsp-link:`rsp` click on the left panel for the Portal.
+```
+
+From `docs/guides/life/quotas.rst` (explicit link title, and a URL with an appended path):
+
+```rst
+Always consult your :rsp-link:`Quotas page <rsp/settings/quotas>` (found under your account settings or directly at :rsp-url:`rsp/settings/quotas`) for limits being currently applied.
+```
+
+Targeting a service absent from the environment being built raises a fatal warning — wrap such references in a matching `rsp-only` block (below).
+
+### Substitutions
+
+For env-specific prose a role can't produce, use substitutions defined in `rst_prolog.rst.jinja` (available on every page).
+From `docs/guides/life/quotas.rst`:
+
+```rst
+As an approved user of the |rsp-at| you have access to certain individual, group, and shared resources.
+```
+
+`|rsp-env|` (plain-text display name), `|rsp-env-link|` (linked display name), and `|rsp-at|` (link to this environment's homepage) are the common ones.
+
+Roles and ordinary substitutions don't expand inside literal blocks. For an environment URL inside a code sample, add the `:substitutions:` option and use a substitution like `|rsp-tap-url|`. From `docs/guides/notebooks/faq/index.rst`:
+
+```rst
+.. code-block:: bash
+   :substitutions:
+
+   export EXTERNAL_TAP_URL="|rsp-tap-url|"
+```
+
+### rsp-only directive
+
+Include a block only where its condition holds. Tokens are service names, environment names, or `primary` (= `idfprod`); default is logical AND, with `:any:` for OR and `:not:` to negate.
+
+From `docs/guides/notebooks/faq/index.rst` — a block (and its lead-in prose) shown only where TAP exists:
+
+```rst
+.. rsp-only:: tap
+
+   As an example, we will walk through how to access the Rubin LSST TAP service locally.
+```
+
+From `docs/guides/recovery/index.rst` — the negated form for "every environment except the primary one":
+
+```rst
+.. rsp-only:: primary
+   :not:
+
+   To recover a staff account, contact one of the RSP environment's administrators or your manager.
+```
+
+### Large divergent block: `*.in.rst` include
+
+To swap a large block per environment, combine `rsp-only` with an `include` of an `*.in.rst` fragment.
+The `.in.rst` suffix keeps Sphinx from building the fragment as its own page; name it `<page-stem>.<context>.in.rst`.
+From `docs/guides/recovery/index.rst`:
+
+```rst
+.. rsp-only:: primary
+
+   .. include:: user-recovery.primary.in.rst
+```
+
+(Real fragment: `docs/guides/recovery/user-recovery.primary.in.rst`.)
+
+### Whole page absent from some environments
+
+This is a **two-part** change that must agree on the gating service.
+
+First, conditionalize the `toctree` entry with a `jinja` directive on the service's URL attribute. From `docs/guides/auth/index.rst`:
+
+```rst
+.. jinja:: rsp
+
+   .. toctree::
+      :titlesonly:
+
+      creating-user-tokens
+      token-scopes
+      {% if env.api_tap_url %}using-topcat-outside-rsp{% endif %}
+```
+
+Second, register the page's source under the matching service token in `src/rspdocs/sphinxext/page_excludes.yaml`, so Sphinx skips it (and doesn't flag it as an orphan) where the service is absent:
+
+```yaml
+tap:
+  - guides/auth/using-topcat-outside-rsp.rst
+```
+
+When excluding an index page that heads a subtree, also exclude the subtree (a `**` glob) so its children don't become orphans.
+
+## 3. Gotchas
+
+- **Never hard-code an environment hostname.** Use a role (or, in code samples, a substitution) so URLs resolve per environment.
+- Referencing a service that's absent from the environment being built is a fatal warning — wrap it in a matching `rsp-only` block.
+- `page_excludes.yaml` (and `environments.json`) are validated by the `rspdocs-validate-config` pre-commit hook: keys must be recognized service tokens, so a typo fails at commit time.
+- An excluded page must not be linked *unconditionally* from a page that builds everywhere — the two-part change (toctree gate + exclude) keeps them in sync.
+
+## 4. Progressive disclosure
+
+This skill covers the common cases only.
+For the full service-name table, code-sample substitutions, the `jinja` directive for *computed* (not just shown/hidden) text, and the details of page excludes, **read `docs/contributing/env-specific-docs.rst`.**
+
+## 5. Verify
+
+Environment-specific mistakes often only show up in the environment they affect, so build at least two environments with differing behavior — the primary plus one where the relevant service is absent:
+
+```bash
+tox -e sphinx-idfprod
+tox -e sphinx-base
+```
+
+(If `tox` is not on `PATH`, use `uvx tox -e …`.)
+Both must be green; read the output for warnings, not just the exit status.

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -38,15 +38,24 @@ Match the heading-underline convention used across this repo (inspect a neighbor
 Use **sentence case** for the title and all headings (capitalize only the first word and proper nouns).
 Use **semantic line breaks**: one sentence (or clause) per source line — never hard-wrap to a fixed column.
 
+**Open with a context-setting paragraph.**
+The first paragraph after the title is a way-finding mechanism: it answers what the page is for (and for whom), so readers landing from search or a link can immediately tell whether they're in the right place.
+Link to related concepts and pages from it where that helps orientation.
+
+**Set an OpenGraph description.**
+Add an `:og:description:` field at the very top of the file (before the title) with a concise one-sentence description; [sphinxext-opengraph](https://sphinxext-opengraph.readthedocs.io/en/latest/#per-page-overrides) uses it for link previews.
+
 Skeleton to adapt:
 
 ```rst
+:og:description: How to start a Notebook server on the Rubin Science Platform and stop it when you're done.
+
 #########################
 Start and stop a server
 #########################
 
-From the RSP landing page, click on the central panel for Notebooks.
-This paragraph uses one sentence per source line.
+This page shows you how to start a Notebook Aspect server and shut it down when you're done.
+This opening paragraph sets context for the reader, one sentence per source line.
 
 Select a server size
 ====================
@@ -60,6 +69,11 @@ Text for a subsection.
 ```
 
 Try not to exceed two levels of heading hierarchy below the title (see the style guide).
+
+### Available Sphinx features
+
+Pages are built with [documenteer's guide configuration](https://documenteer.lsst.io/guides/index.html), so its bundled extensions are available without any conf changes — including [sphinx-design](https://sphinx-design.readthedocs.io/) tab sets, badges, and cards.
+Use these where they genuinely aid the reader (e.g. a `tab-set` for per-platform instructions); see the documenteer guides documentation for the full feature list.
 
 ## 3. Register the page in the parent toctree
 

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -21,8 +21,9 @@ Pick the section under `docs/` that fits the content:
 File-name rules:
 
 - Lowercase, with hyphens between words. Never underscores or spaces (e.g. `starting-and-stopping`, not `starting_and_stopping`).
-- A page **with images** (or that heads a subsection) lives in its own directory as `index.rst`, with images in a sibling `images/` directory — e.g. `docs/guides/notebooks/starting-and-stopping/index.rst` and `docs/guides/notebooks/starting-and-stopping/images/`.
-- A simple single-file page can live directly in the section — e.g. `docs/guides/life/quotas.rst`.
+- A page **with images** (or that heads a subsection) has historically lived in its own directory as `index.rst`, with images in a sibling `images/` directory — e.g. `docs/guides/notebooks/starting-and-stopping/index.rst` and `docs/guides/notebooks/starting-and-stopping/images/`.
+  **Treat this as an anti-pattern to unwind, not a model to copy**: going forward, reserve `index.rst` for genuine index pages (ones that contain a `toctree`), and put images alongside the prose file that uses them.
+- Prefer a single-file page named for its topic, directly in the section — e.g. `docs/guides/life/quotas.rst`.
 
 Inspect the neighboring pages in the section you chose and match their layout.
 

--- a/.claude/skills/new-page/SKILL.md
+++ b/.claude/skills/new-page/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: new-page
+description: Scaffold a new documentation page for rsp.lsst.io — file placement, reStructuredText skeleton, heading style, and toctree registration. Use when adding a new page or section to the docs.
+---
+
+# Scaffold a new documentation page
+
+Use this playbook to add a new page to rsp.lsst.io.
+The docs are Sphinx reStructuredText under `docs/`, built once per RSP environment with `-W` (warnings are fatal).
+Full editorial rules live in `docs/contributing/style-guide.rst` — this skill is the quick procedure, not a replacement for it.
+
+## 1. Choose the location and file name
+
+Pick the section under `docs/` that fits the content:
+
+- `docs/guides/` — the bulk of user documentation (getting-started, notebooks, portal, API, auth, WebDAV, Times Square, recovery, life-of-an-account). New user-facing content almost always belongs here.
+- `docs/contributing/` — how to write and build the docs.
+- `docs/support/` — how users get help.
+- `docs/updates/` — release/update notes.
+
+File-name rules:
+
+- Lowercase, with hyphens between words. Never underscores or spaces (e.g. `starting-and-stopping`, not `starting_and_stopping`).
+- A page **with images** (or that heads a subsection) lives in its own directory as `index.rst`, with images in a sibling `images/` directory — e.g. `docs/guides/notebooks/starting-and-stopping/index.rst` and `docs/guides/notebooks/starting-and-stopping/images/`.
+- A simple single-file page can live directly in the section — e.g. `docs/guides/life/quotas.rst`.
+
+Inspect the neighboring pages in the section you chose and match their layout.
+
+## 2. Write the reStructuredText skeleton
+
+Match the heading-underline convention used across this repo (inspect a neighbor to confirm):
+
+- Top-level page title: `#` characters as an **overline and underline**, both at least as long as the title.
+- Section headings: `=` underline.
+- Subsection headings: `-` underline.
+
+Use **sentence case** for the title and all headings (capitalize only the first word and proper nouns).
+Use **semantic line breaks**: one sentence (or clause) per source line — never hard-wrap to a fixed column.
+
+Skeleton to adapt:
+
+```rst
+#########################
+Start and stop a server
+#########################
+
+From the RSP landing page, click on the central panel for Notebooks.
+This paragraph uses one sentence per source line.
+
+Select a server size
+====================
+
+Text for the first section.
+
+A narrower detail
+-----------------
+
+Text for a subsection.
+```
+
+Try not to exceed two levels of heading hierarchy below the title (see the style guide).
+
+## 3. Register the page in the parent toctree
+
+**A page that no `toctree` links to fails the `-W` build** with `document isn't included in any toctree` (an "orphan").
+After creating the page, add its name (without the `.rst` extension, or the directory name for an `index.rst` page) to the `toctree` of the parent `index.rst`.
+
+For example, `docs/guides/getting-started/index.rst` registers pages like this:
+
+```rst
+.. toctree::
+   :caption: Account set up
+   :titlesonly:
+
+   get-an-account
+   linking-more-ids
+```
+
+Add your new page's stem on its own line inside the appropriate `toctree`.
+For a page in its own directory, register the directory-relative path to its index, e.g. `starting-and-stopping/index`.
+
+## 4. Style reminders
+
+- Address the reader as **"you"**, never **"we"** (name "Rubin Observatory" if that's what's meant).
+- **Never use "here" as link text** — make the relevant noun or phrase the link.
+- Write in the active voice and present tense; short sentences and paragraphs.
+
+These are the essentials only. Read `docs/contributing/style-guide.rst` for the full guidance before writing substantial prose.
+
+## 5. Environment-specific content
+
+If the page's content varies across RSP environments — it mentions an RSP service URL, differs by environment, or should be dropped from some environments — **use the `env-specific-content` skill**.
+Never hard-code an environment hostname; the env-specific machinery (roles, substitutions, `rsp-only`, includes, page excludes) resolves it per environment.
+
+## 6. Verify
+
+Build the primary environment and read the output for warnings, not just the exit status:
+
+```bash
+tox -e sphinx-idfprod
+```
+
+(If `tox` is not on `PATH`, use `uvx tox -e sphinx-idfprod`.)
+The build must be green — a fatal warning here usually means an unregistered page (step 3) or a broken cross-reference.
+If the page has environment-varying content, also build a non-primary environment (see the `env-specific-content` skill).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,6 +86,13 @@ Biggest gotchas:
 
 Read the relevant page(s) under `docs/contributing/` before writing or restructuring content — `style-guide.rst` for conventions, `env-specific-docs.rst` for anything that varies by environment, and `building-the-docs.rst` for the build workflow. These are the source of truth; this file only points at them.
 
+## Repo skills
+
+This repo ships agent skills — step-by-step playbooks for common tasks — under `.claude/skills/` (mirrored at `.agents/skills` for non-Claude harnesses). Load the matching skill when you start one of these tasks:
+
+- **`new-page`** — scaffolding a new documentation page: file placement, the reStructuredText skeleton, heading style, and toctree registration. Use when adding a new page or section.
+- **`env-specific-content`** — writing content that differs across RSP environments: the `rsp-url`/`rsp-link` roles, the `rsp-only` directive, substitutions, `*.in.rst` includes, and page excludes. Use whenever content mentions an environment URL or varies per environment.
+
 ## Branch convention
 
 Work on a branch named `tickets/DM-XXXXX`, using the Jira ticket key for the work.


### PR DESCRIPTION
## Summary

- Adds two agent skills under `.claude/skills/` packaging the repo's non-obvious authoring procedures as on-demand playbooks: **new-page** (scaffolding a guide page: placement/naming, rst skeleton with the repo's heading conventions, toctree registration and the `-W` orphan failure, style pointers, build verification) and **env-specific-content** (a decision table mapping each situation to the right mechanism — `rsp-url`/`rsp-link` roles, substitutions, `rsp-only`, `.in.rst`/`.primary.in.rst` includes, `page_excludes.yaml` — with examples drawn from real usage in `docs/`, plus gotchas and an explicit deferral to `docs/contributing/env-specific-docs.rst`).
- Adds `.agents/skills` as a relative symlink to `../.claude/skills` so non-Claude agent harnesses discover the same skills.
- Updates `AGENTS.md` with a "Repo skills" section naming both skills and when to use them.

## Validation steps

- [ ] `test -L .agents/skills && readlink .agents/skills` prints `../.claude/skills`, and `git ls-files -s .agents/skills` shows mode `120000`
- [ ] Skim both `SKILL.md` files and spot-check their rst examples against the source pages they cite (e.g. `docs/guides/notebooks/faq/index.rst`, `docs/guides/recovery/index.rst`, `docs/guides/auth/index.rst`, `src/rspdocs/sphinxext/page_excludes.yaml`)
- [ ] Optionally follow the new-page skill literally to scaffold a throwaway page and confirm `tox -e sphinx-idfprod` passes with it registered (this dry-run was performed during development, then reverted)

## References

- Closes #99
- Jira: https://rubinobs.atlassian.net/browse/DM-55528