### PR TITLE
DM-55528: Add vale editorial linter (Google + RSP styles)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -89,6 +89,12 @@ jobs:
 
       - name: Run Vale
         uses: errata-ai/vale-action@v2
+        # Vale is advisory: annotations should appear on the PR, but the
+        # check must stay green. fail_on_error alone isn't enough — the
+        # action still fails the step when reviewdog exits nonzero (for
+        # example when a prose-heavy PR overflows GitHub's per-step
+        # annotation cap), so tolerate any step failure outright.
+        continue-on-error: true
         with:
           # vale-action runs `vale sync` to download the Google package.
           # The default reporter (github-pr-annotations) works with the

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,6 +65,38 @@ jobs:
           python-version: ${{ env.PYTHON_VERSION }}
           tox-envs: "py,typing"
 
+  # Advisory prose linting with Vale (https://vale.sh). This job is
+  # deliberately non-blocking: vale-action runs reviewdog with
+  # fail_on_error: false and filter_mode: added, so findings surface as
+  # inline annotations on changed lines only and the job stays green even
+  # when Vale reports issues. See docs/contributing/vale.rst.
+  vale:
+    runs-on: ubuntu-latest
+    # Annotations are only meaningful on pull requests (reviewdog needs a diff).
+    if: ${{ github.event_name == 'pull_request' }}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # Vale shells out to rst2html (docutils) to parse reStructuredText.
+      - name: Install docutils
+        run: pip install docutils
+
+      - name: Run Vale
+        uses: errata-ai/vale-action@v2
+        with:
+          # vale-action runs `vale sync` to download the Google package.
+          # The default reporter (github-pr-annotations) works with the
+          # read-only GITHUB_TOKEN on forked PRs, unlike github-pr-check.
+          fail_on_error: false
+          filter_mode: added
+          files: docs
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/periodic-ci.yaml
+++ b/.github/workflows/periodic-ci.yaml
@@ -62,6 +62,40 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_ALERT_WEBHOOK }}
 
+  # Advisory full-corpus Vale report. Non-blocking: it always succeeds and
+  # uploads the report as an artifact for review. It does not affect the
+  # build matrix or the Slack notifications. See docs/contributing/vale.rst.
+  vale-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+
+      # Vale (PyPI) ships the binary; docutils supplies rst2html for RST.
+      - name: Install Vale and docutils
+        run: pip install vale docutils
+
+      - name: Sync Vale packages
+        run: vale sync
+
+      # Run over the whole included corpus and capture the report. The path
+      # exclusions in .vale.ini (updates, inbox drafts, roadmap) still apply;
+      # `|| true` keeps the step green even though Vale exits non-zero when it
+      # has findings.
+      - name: Run Vale over the full corpus
+        run: vale docs/ | tee vale-report.txt || true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: vale-report
+          path: vale-report.txt
+          if-no-files-found: warn
+
   build:
     runs-on: ubuntu-latest
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,11 @@ _build
 # automodapi-generated API stub pages for lsst.rsp
 docs/guides/notebooks/lsst.rsp/api/
 
+# Vale external style packages synced by `vale sync` (see .vale.ini).
+# The RSP style (styles/RSP) and vocabulary (styles/config) are committed;
+# the downloaded Google package is not.
+/styles/Google/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.vale.ini
+++ b/.vale.ini
@@ -1,0 +1,104 @@
+# Vale configuration for rsp.lsst.io.
+#
+# Vale (https://vale.sh) provides advisory editorial linting of the prose in
+# this repository. Findings are informational: they never fail CI. See
+# docs/contributing/vale.rst for how to run and tune Vale.
+#
+# The Google package (styles/Google) is synced by `vale sync` and is
+# gitignored; the RSP style and the RSP vocabulary are committed.
+
+StylesPath = styles
+
+# External style packages downloaded by `vale sync`.
+Packages = Google
+
+# Project vocabulary (styles/config/vocabularies/RSP/accept.txt).
+Vocab = RSP
+
+# Accept RST prose natively. Vale shells out to rst2html (docutils), which the
+# tox -e vale environment and the CI job install alongside Vale.
+[*.{rst,md}]
+BasedOnStyles = Vale, Google, RSP
+
+# --- Tuning (see docs/contributing/vale.rst and issue rationale) ------------
+# Google rules demoted or disabled because they produce a high volume of
+# low-value flags on this corpus. Each carries a one-line rationale.
+
+# Sentence-length heuristic fires constantly on legitimate technical prose.
+Google.Sentences = NO
+
+# Passive-voice detection is noisy and often wrong on procedural docs.
+Google.Passive = NO
+
+# Heading capitalization: this repo uses sentence case (checked by review),
+# but Google.Headings mis-parses RST directive titles and product names.
+Google.Headings = NO
+
+# "Will"/future tense is idiomatic and unavoidable in roadmap/scheduling prose.
+Google.Will = suggestion
+
+# Ordinal/spelled-number and units rules flag many correct technical usages.
+Google.Units = suggestion
+Google.Ordinal = suggestion
+
+# House style *encourages* contractions, and this rule agrees — it suggests
+# "don't" over "do not" — so keep it as a low-key suggestion.
+Google.Contractions = suggestion
+
+# RSP.We replaces Google.We (same "we" house rule, with our wording and links).
+Google.We = NO
+
+# "RSP", "TAP", "API" etc. appear on nearly every page; spelling them out on
+# each mention is not this project's convention (109 flags, no value).
+Google.Acronyms = NO
+
+# Parenthetical asides are common and acceptable in this procedural prose
+# (190 flags — by far the noisiest rule on this corpus).
+Google.Parens = NO
+
+# Google.Latin flags "e.g."/"i.e.", which house style permits. Disable.
+Google.Latin = NO
+
+# Vale.Terms enforces case consistency across the whole corpus and fires (at
+# error level) on tokens that are correct in context — "rsp" inside URLs and
+# package names, "Jupyter" vs "jupyter" commands. Too noisy to be useful here.
+Vale.Terms = NO
+
+# Em-dash spacing preference; house style is relaxed about this.
+Google.EmDash = NO
+
+# Exclamation and first-person are covered adequately; keep as suggestions.
+Google.Exclamation = suggestion
+
+# --- Path exclusions --------------------------------------------------------
+# These paths are excluded from linting. Vale merges glob sections, so an
+# excluded section must both clear BasedOnStyles *and* silence every rule that
+# was individually enabled above (Vale keeps a per-rule key set in a broader
+# section unless a narrower section overrides it).
+
+# Historical release/update notes: frozen, not worth re-editing.
+[docs/updates/**]
+BasedOnStyles =
+Google.Will = NO
+Google.Units = NO
+Google.Ordinal = NO
+Google.Exclamation = NO
+Google.Contractions = NO
+
+# Rough drafts staged in the inbox.
+[docs/guides/inbox/**]
+BasedOnStyles =
+Google.Will = NO
+Google.Units = NO
+Google.Ordinal = NO
+Google.Exclamation = NO
+Google.Contractions = NO
+
+# Roadmap prose is aspirational and future-tense by nature.
+[docs/roadmap.rst]
+BasedOnStyles =
+Google.Will = NO
+Google.Units = NO
+Google.Ordinal = NO
+Google.Exclamation = NO
+Google.Contractions = NO

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ Because content can differ across environments, authoring often uses the environ
 - `tox -e py` — run the pytest suite.
 - `tox -e typing` — run mypy over `src/rspdocs` and `tests`.
 - `tox -e lint` — run all pre-commit hooks over the tree.
+- `tox -e vale` — run the [Vale](https://vale.sh) editorial linter (Google + RSP styles) over `docs/`. Findings are **advisory**: they never fail CI (a non-zero exit just means Vale had something to report), there is no pre-commit hook, and on pull requests the CI annotations are non-blocking. See `docs/contributing/vale.rst`. Accept legitimate terms in `styles/config/vocabularies/RSP/accept.txt`; fix real typos in the source.
 - `tox -e linkcheck-idfprod` — check external links for that environment (a `linkcheck-{env}` exists per environment).
 
 **Builds run under `-W`, so every Sphinx warning is fatal.**

--- a/docs/contributing/index.rst
+++ b/docs/contributing/index.rst
@@ -39,3 +39,4 @@ Guides
    building-the-docs
    env-specific-docs
    style-guide
+   vale

--- a/docs/contributing/vale.rst
+++ b/docs/contributing/vale.rst
@@ -15,7 +15,7 @@ What Vale checks
 Vale runs three sets of rules over the ``.rst`` and ``.md`` files under ``docs/``:
 
 - ``Vale.Spelling`` — spell-checking, using the project vocabulary (see below) for legitimate project and astronomy terms.
-- **Google** — the Google Developer Documentation Style Guide package, tuned for this corpus. Some of its rules are demoted to suggestions or disabled where they produce noise; see the comments in ``.vale.ini`` for the rationale behind each adjustment.
+- **Google** — the Google Developer Documentation Style Guide package, tuned for this corpus. Some of its rules are demoted to suggestions or turned off where they produce noise. See the comments in ``.vale.ini`` for the rationale behind each adjustment.
 
 .. vale off
 
@@ -37,7 +37,7 @@ Run Vale over the documentation with tox:
    tox -e vale
 
 This installs Vale and docutils, runs ``vale sync`` to download the Google package into ``styles/`` (which is gitignored), and lints ``docs/``.
-A non-zero exit code just means Vale found something to report; it is not an error.
+A non-zero exit code just means Vale found something to report — it's not an error.
 
 On a pull request, GitHub Actions runs Vale too, and posts any findings on the lines you changed as inline annotations.
 That job is always green, even when Vale has findings.
@@ -47,16 +47,17 @@ Adding words to the vocabulary
 
 When Vale flags a legitimate project term, an astronomy term, or a piece of software as a misspelling, add it to the project vocabulary rather than working around it.
 The vocabulary is a plain-text file at ``styles/config/vocabularies/RSP/accept.txt``.
-Each line is a case-sensitive regular expression; add the term on its own line, grouped under the appropriate comment heading.
+Each line is a case-sensitive regular expression.
+Add the term on its own line, grouped under the appropriate comment heading.
 
-Before you accept a word, make sure it is genuinely a term and not a typo.
+Before you accept a word, make sure it's genuinely a term and not a typo.
 The `lsst-texmf glossary <https://github.com/lsst/lsst-texmf/blob/main/etc/glossarydefs.csv>`__ is a useful reference for the canonical spelling of Rubin Observatory terms.
 If a flagged word is actually a typo, fix it in the source instead of accepting it.
 
 Suppressing false positives
 ===========================
 
-Occasionally a rule fires on something that is correct in context.
+Occasionally a rule fires on something that's correct in context.
 When that happens, you can turn Vale off for a span of source with comments:
 
 .. code-block:: rst

--- a/docs/contributing/vale.rst
+++ b/docs/contributing/vale.rst
@@ -1,0 +1,71 @@
+##############################
+Editorial linting with Vale
+##############################
+
+This project uses Vale_ to lint the prose in the documentation against the :doc:`style-guide` and the `Google Developer Documentation Style Guide`_.
+Vale's feedback is *advisory*: it never fails a build or blocks a pull request.
+Use it as a checklist of things to look at, not as a gate.
+
+.. _Vale: https://vale.sh
+.. _`Google Developer Documentation Style Guide`: https://developers.google.com/style/
+
+What Vale checks
+================
+
+Vale runs three sets of rules over the ``.rst`` and ``.md`` files under ``docs/``:
+
+- ``Vale.Spelling`` — spell-checking, using the project vocabulary (see below) for legitimate project and astronomy terms.
+- **Google** — the Google Developer Documentation Style Guide package, tuned for this corpus. Some of its rules are demoted to suggestions or disabled where they produce noise; see the comments in ``.vale.ini`` for the rationale behind each adjustment.
+
+.. vale off
+
+- **RSP** — a small set of house rules drawn from the :doc:`style-guide`, such as addressing the reader as "you" rather than "we" and not using "here" as link text.
+
+.. vale on
+
+The configuration lives in ``.vale.ini`` at the repository root, and the RSP rules live in ``styles/RSP/``.
+
+Some paths are excluded because their prose is frozen or provisional: the dated release notes under ``docs/updates/``, the rough drafts in ``docs/guides/inbox/``, and ``docs/roadmap.rst``.
+
+Running Vale locally
+====================
+
+Run Vale over the documentation with tox:
+
+.. code-block:: bash
+
+   tox -e vale
+
+This installs Vale and docutils, runs ``vale sync`` to download the Google package into ``styles/`` (which is gitignored), and lints ``docs/``.
+A non-zero exit code just means Vale found something to report; it is not an error.
+
+On a pull request, GitHub Actions runs Vale too, and posts any findings on the lines you changed as inline annotations.
+That job is always green, even when Vale has findings.
+
+Adding words to the vocabulary
+==============================
+
+When Vale flags a legitimate project term, an astronomy term, or a piece of software as a misspelling, add it to the project vocabulary rather than working around it.
+The vocabulary is a plain-text file at ``styles/config/vocabularies/RSP/accept.txt``.
+Each line is a case-sensitive regular expression; add the term on its own line, grouped under the appropriate comment heading.
+
+Before you accept a word, make sure it is genuinely a term and not a typo.
+The `lsst-texmf glossary <https://github.com/lsst/lsst-texmf/blob/main/etc/glossarydefs.csv>`__ is a useful reference for the canonical spelling of Rubin Observatory terms.
+If a flagged word is actually a typo, fix it in the source instead of accepting it.
+
+Suppressing false positives
+===========================
+
+Occasionally a rule fires on something that is correct in context.
+When that happens, you can turn Vale off for a span of source with comments:
+
+.. code-block:: rst
+
+   .. vale off
+
+   This text is not linted by Vale.
+
+   .. vale on
+
+Use this sparingly, and only for genuine false positives — for example, a required verbatim string that happens to trip a rule.
+Prefer adding a real term to the vocabulary over switching Vale off, and never use ``.. vale off`` to silence a legitimate style issue that you should fix instead.

--- a/docs/contributing/vale.rst
+++ b/docs/contributing/vale.rst
@@ -1,6 +1,6 @@
-##############################
+###########################
 Editorial linting with Vale
-##############################
+###########################
 
 This project uses Vale_ to lint the prose in the documentation against the :doc:`style-guide` and the `Google Developer Documentation Style Guide`_.
 Vale's feedback is *advisory*: it never fails a build or blocks a pull request.

--- a/docs/guides/auth/groups.rst
+++ b/docs/guides/auth/groups.rst
@@ -9,10 +9,10 @@ Create and manage closed user groups in order to share private files.
 Create a group
 ==============
 
-Groups are created an managed in the Comanage system at `id.lsst.cloud <https://id.lsst.cloud>`_
+Groups are created and managed in the COmanage system at `id.lsst.cloud <https://id.lsst.cloud>`_
 (not from the terminal command line, as in some other systems).
 
-How to create a closed group in Comanage:
+How to create a closed group in COmanage:
 
 * In a browser, navigate to `id.lsst.cloud <https://id.lsst.cloud>`_ and log in.
 
@@ -48,12 +48,12 @@ Manage group membership
 Only group owners can manage closed-group membership.
 
 A user can only be a member of up to 15 groups at this time.
-Joining additional groups will have no effect: they will show up in the Comanage UI, but will not have any effect on actual authorization to access directories and files.
+Joining additional groups will have no effect: they will show up in the COmanage UI, but will not have any effect on actual authorization to access directories and files.
 
 From the terminal command line it is possible to see all groups a user belongs to with ``groups <username>``
 (see your own username with ``whoami``).
 
-How to manage group membership in Comanage:
+How to manage group membership in COmanage:
 
 * In a browser, navigate to `id.lsst.cloud <https://id.lsst.cloud>`_ and log in.
 * In the left menu sidebar, click on "Groups" and then "My Groups".
@@ -72,7 +72,7 @@ Set directory permissions
 
 The point of creating a closed group is to permit group members to access privately shared files.
 
-Shared files are not managed via the Comanage webpage; use the terminal command line in the Notebook Aspect.
+Shared files are not managed via the COmanage webpage; use the terminal command line in the Notebook Aspect.
 
 These instructions are not all unique to the Rubin Science Platform or JupyterLab;
 some are generic processes for manipulating directory permissions in Unix-like operating systems.

--- a/docs/guides/auth/token-scopes.rst
+++ b/docs/guides/auth/token-scopes.rst
@@ -27,7 +27,7 @@ To learn how to create a token, see :doc:`creating-user-tokens`.
     Execute SELECT queries in the TAP interface on project datasets.
 
 ``write:files``
-    Write files in the user's directories (eg via WebDAV)
+    Write files in the user's directories (e.g. via WebDAV)
 
 ``user:token``
     Create and modify user tokens.

--- a/docs/guides/auth/using-topcat-outside-rsp.rst
+++ b/docs/guides/auth/using-topcat-outside-rsp.rst
@@ -1,5 +1,5 @@
 #################################################################
-Tutorial: Authenticating from TOPCat outside the Science Platform
+Tutorial: Authenticating from TOPCAT outside the Science Platform
 #################################################################
 
 This tutorial shows you how to access the Rubin Science Platform datasets from outside the Science Platform with :doc:`user tokens <creating-user-tokens>`.
@@ -20,7 +20,7 @@ This example specifically shows how to access table data from the Science Platfo
 #. From TOPCAT, select :menuselection:`VO --> Table Access Protocol (TAP) Query`.
 
   .. image:: images/topcat-vo-menu.png
-     :alt: The VO menue
+     :alt: The VO menu
 
 #. This will bring up a window with a list of available TAP services.
    We want to use a service with a known endpoint.

--- a/docs/guides/notebooks/configuration/user-installs.rst
+++ b/docs/guides/notebooks/configuration/user-installs.rst
@@ -68,4 +68,4 @@ The basic steps are:
 
 	export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${HOME}/local/MultiNest/lib
 
-6. After the first time perfoming Steps 4 and/or 5, log out and log back into the RSP.
+6. After the first time performing Steps 4 and/or 5, log out and log back into the RSP.

--- a/docs/guides/notebooks/index.rst
+++ b/docs/guides/notebooks/index.rst
@@ -21,7 +21,7 @@ The Notebook aspect offers a variety of functionality, including:
 
 * programmatic access and analysis of LSST data
 * :doc:`Jupyter Notebooks <jupyter-notebooks/index>`
-* :doc:`terminal <jupyterlab-terminal/index>` and iPython interface
+* :doc:`terminal <jupyterlab-terminal/index>` and IPython interface
 * stable, Python-based software environment
 * pre-installed `LSST Science Pipelines`_
 * shared computational resources and disk space

--- a/docs/guides/notebooks/starting-and-stopping/index.rst
+++ b/docs/guides/notebooks/starting-and-stopping/index.rst
@@ -53,7 +53,7 @@ Return to this launch pad at any time by clicking the blue plus symbol at upper-
 
 In the narrow left-most vertical sidebar of icons, the top icon is a file folder, and that is the default view for the left sidebar.
 The wider part of the left sidebar lists folders in the user's home directory (e.g., DATA, WORK, and notebooks).
-Launching a terminal (the default is a linux bash terminal) and using the command "ls" will return the same list.
+Launching a terminal (the default is a Linux bash terminal) and using the command "ls" will return the same list.
 Navigate the file system and open files by double-clicking on folders and files in the left sidebar.
 Clicking the folder icon above the list of files will take you back to your home directory.
 

--- a/styles/RSP/LinkText.yml
+++ b/styles/RSP/LinkText.yml
@@ -1,0 +1,14 @@
+extends: existence
+message: "Don't use '%s' as link text; make the relevant noun or phrase the link."
+link: https://rsp.lsst.io/contributing/style-guide.html
+# House style (docs/contributing/style-guide.rst, "Links"): never use "here"
+# as link text. This flags the RST hyperlink forms `here <url>`_ and
+# `click here <url>`_ (and "this page"), where the visible text precedes the
+# angle-bracketed target, plus the :doc:/:ref: role forms with the same text.
+# Matching is case-insensitive so `Click here <url>`_ is also caught.
+level: warning
+nonword: true
+scope: raw
+tokens:
+  - '(?i)`\s*(?:here|click here|this page)\s*<[^>]+>`_'
+  - '(?i):(?:doc|ref):`\s*(?:here|click here|this page)\s*<[^>]+>`'

--- a/styles/RSP/We.yml
+++ b/styles/RSP/We.yml
@@ -1,0 +1,18 @@
+extends: existence
+message: "Address the reader as 'you', not '%s'. If you mean the project, name 'Rubin Observatory'."
+link: https://rsp.lsst.io/contributing/style-guide.html
+# House style (docs/contributing/style-guide.rst, "Style and voice"): never
+# use "we" — it is ambiguous. Say "you" for the reader, or name "Rubin
+# Observatory" for the project. Supplements Google.We, whose token coverage of
+# reStructuredText prose on this corpus is thin.
+level: warning
+ignorecase: true
+tokens:
+  # "us" is deliberately omitted: it collides with "US" (US Pacific time, US
+  # facilities) far more often than it appears as the first-person pronoun.
+  - "we"
+  - "we're"
+  - "we've"
+  - "we'll"
+  - "our"
+  - "ours"

--- a/styles/config/vocabularies/RSP/accept.txt
+++ b/styles/config/vocabularies/RSP/accept.txt
@@ -1,0 +1,84 @@
+# RSP vocabulary -- case-sensitive accepted spellings for Vale.Spelling.
+# Built empirically from a full-corpus spelling pass (issue #100 / DM-55528).
+# Entries are regular expressions; add legitimate project, astronomy, and
+# software terms here. Fix genuine typos in the source instead of accepting
+# them. See docs/contributing/vale.rst.
+
+# --- Rubin / RSP project terms ----------------------------------------------
+RSP
+RSPClient
+RSPDiscovery
+COmanage
+CILogon
+Onboarding
+onboarding
+Chronograf
+Grafana
+TOPCAT
+
+# --- People (release-note / credit lines) -----------------------------------
+Germanotta
+Jenness
+Shaughnessy
+Stefani
+
+# --- Astronomy / science terms ----------------------------------------------
+coadd
+coadded
+dayobs
+
+# --- Software / tooling terms -----------------------------------------------
+APIs?
+[Bb]oolean
+[Bb]ools?
+[Cc]onda
+config
+repo
+subtree
+templated
+toctree
+[Cc]onditionaliz(e|es|ed|ing)
+ipython
+IPython
+jinja
+jupyter
+Makefile
+pdb
+pyvo
+venv
+tox
+docutils
+gitignored
+gh
+emacs
+middleware
+traceback
+unexecuted
+preconfigured
+allowlist
+browsable
+grayscale
+scrollbar
+[Ss]crollbars?
+[Aa]utosaves?
+[Ss]ignup
+iCalendar
+[Pp]arameteriz(e|es|ed|ing|ation|ations)
+lsst_distrib
+pipe_tasks
+Astro
+Astropy
+nbstripout
+situ
+
+# --- RST syntax / code-identifier artifacts ---------------------------------
+# Snake_case identifiers (API function names, config keys) read as prose by
+# Vale's spell checker; accept any lowercase snake_case token.
+[a-z][a-z0-9]*(_[a-z0-9]+)+
+# Trailing-underscore RST reference names (e.g. `Astroplan_`, `tox_`).
+[A-Za-z][A-Za-z0-9_]*_
+# Common short technical tokens.
+DM
+LSST
+Docs
+Booleans

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,22 @@ extras =
 commands =
     mypy src/rspdocs tests --explicit-package-bases
 
+[testenv:vale]
+description = Run the Vale editorial linter over docs (advisory; never blocks).
+skip_install = true
+deps =
+    vale
+    # docutils supplies rst2html, which Vale shells out to for parsing RST.
+    docutils
+# `vale sync` downloads the Google package into styles/ (gitignored); then
+# lint docs/. A nonzero exit just means Vale had findings — that is expected
+# and informative, so ignore the exit status locally.
+commands =
+    vale sync
+    # Path exclusions (updates, inbox drafts, roadmap) are declared in
+    # .vale.ini. The leading "-" ignores Vale's nonzero exit.
+    - vale docs/
+
 [testenv:lint]
 description = Lint code and configurations by running pre-commit.
 # Install the package so the rspdocs-validate-config console script (used by


### PR DESCRIPTION
## Summary

- Adds [vale](https://vale.sh) prose linting configured for this repo's house style, as **advisory feedback that never fails CI**: the Google Developer Documentation Style Guide package plus a custom `RSP` style (`LinkText`: no "here"/"click here"/"this page" as link text in rst hyperlinks or `:doc:`/`:ref:` roles, case-insensitive; `We`: address the reader as "you", with "us" deliberately omitted to avoid "US" collisions).
- Noisy Google rules are demoted or disabled with a per-rule rationale comment in `.vale.ini` (e.g. `Parens` at 190 flags and `Acronyms` at 109 disabled; `Will` demoted; `Contractions` kept as a suggestion since house style encourages contractions). `docs/updates/`, `docs/guides/inbox/`, and `docs/roadmap.rst` are excluded (verified to produce zero alerts). **Final full-corpus count: 300 alerts — 31 errors, 92 warnings, 177 suggestions.**
- The vocabulary (`styles/config/vocabularies/RSP/accept.txt`) was built empirically from a full-corpus spelling pass; the same pass surfaced **8 real typos, fixed in this PR** (menue→menu, perfoming→performing, TOPCat→TOPCAT, eg→e.g., Comanage→COmanage, "created an managed"→"created and managed", iPython→IPython, linux→Linux).
- Runners: `tox -e vale` locally; a non-blocking `vale` job in `ci.yaml` (`errata-ai/vale-action@v2`, `fail_on_error: false`, `filter_mode: added`, default fork-safe reporter) annotating only changed lines; a `vale-report` artifact job in `periodic-ci.yaml` (build matrix and Slack notifications untouched).
- Docs: new `docs/contributing/vale.rst` covering usage, vocabulary additions, and `.. vale off` exceptions (it demonstrates one on itself); `AGENTS.md` notes the advisory tox env. The synced Google package is gitignored; only `.vale.ini`, the RSP style, and the vocab are committed.

## Validation steps

- [ ] `tox -e vale` runs end-to-end on a clean checkout (syncs the Google package, lints `docs/`; findings are expected and don't fail the run)
- [ ] `git status --porcelain styles/` after a vale run shows no untracked synced-package files
- [ ] Spot-check `accept.txt` entries are legitimate terms and skim the typo-fix hunks in `docs/`
- [ ] Confirm the `vale` CI job on this PR is green while posting inline annotations (this PR touches enough prose to trigger some)
- [ ] Trigger `periodic-ci.yaml` via workflow_dispatch after merge and confirm the `vale-report` artifact uploads

## References

- Closes #100
- Jira: https://rubinobs.atlassian.net/browse/DM-55528