### PR TITLE
DM-55245: Add dataset-aware roles and discovery data table

### DIFF
--- a/.claude/skills/env-specific-content/SKILL.md
+++ b/.claude/skills/env-specific-content/SKILL.md
@@ -19,6 +19,9 @@ Reach from the most targeted to the most general:
 | Situation | Mechanism |
 | --- | --- |
 | A URL or link to an RSP service | `rsp-url` / `rsp-link` role |
+| A URL or link to a **specific dataset's** service (e.g. `dp1`'s TAP endpoint) | `rsp-data-url` / `rsp-data-link` role |
+| A link to a dataset's own documentation site | `rsp-dataset-docs` role |
+| A table of which datasets expose which data-access services | `rsp-data-table` directive |
 | An env-specific word, name, or phrase a role can't produce | substitution (`\|rsp-env\|`, `\|rsp-at\|`, …) |
 | A paragraph or section shown only in some environments | `rsp-only` directive |
 | A large block of divergent content | `rsp-only` (or `jinja`) + an `*.in.rst` include |
@@ -45,6 +48,17 @@ Always consult your :rsp-link:`Quotas page <rsp/settings/quotas>` (found under y
 ```
 
 Targeting a service absent from the environment being built raises a fatal warning — wrap such references in a matching `rsp-only` block (below).
+
+### Dataset-aware roles and the availability table
+
+Discovery describes services *per dataset* too. Three roles and a directive expose that dimension; all resolve against the environment being built.
+
+- `:rsp-data-url:`service dataset`` — a code literal of a dataset's data-access service URL. Service is one of `tap`, `sia`, `cutout`, `datalink`, `hips`; dataset is a name like `dp1`, `dp02`, `dp03`. Example: `:rsp-data-url:`tap dp1``. A path may follow the dataset (`tap dp1/tables`).
+- `:rsp-data-link:`service dataset`` — the hyperlink twin, with the usual `title <service dataset>` form.
+- `:rsp-dataset-docs:`dataset`` — a link to a dataset's own docs site (discovery's `docs_url`), with a `title <dataset>` form.
+- `.. rsp-data-table::` — a table of datasets × data-access services for the current environment, each available cell linking to the endpoint (datasets exposing none of these services are omitted; no datasets at all → no output). Options: `:services:` / `:datasets:` to narrow rows/columns, `:scope: environments` (+ `:service:`) for a datasets × dataset-serving-environments matrix, `:title:` for a caption.
+
+A dataset/service absent in the environment being built (or a dataset with no `docs_url`) raises a fatal warning, so wrap dataset references in an `rsp-only` block. Careful: the per-dataset service names (`sia`, `cutout`, `datalink`, `hips`) are NOT valid `rsp-only` conditions — only `tap` and `api` double as both. Gate on `api` (true wherever the environment serves datasets), `tap`, or environment names, and build the affected environments to confirm the guarded content resolves everywhere the condition holds. The `rsp-data-table` belongs inside `.. rsp-only:: api` so its lead-in prose is dropped where the environment serves no datasets. See `docs/guides/api/api.primary.in.rst` for a real use.
 
 ### Substitutions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,15 @@ Content that differs across RSP environments must use the project's machinery ra
 - **`rsp-url` / `rsp-link` roles** — resolve a named RSP service (e.g. `rsp`,
   `portal`, `nublado`, `tap`) to its URL (or a hyperlink) for the environment
   being built, optionally with a path appended. Use these for any RSP service URL.
+- **`rsp-data-url` / `rsp-data-link` / `rsp-dataset-docs` roles** — resolve a
+  *specific dataset's* data-access service URL (e.g. `:rsp-data-url:`tap dp1``),
+  a hyperlink to it, or a link to a dataset's own documentation site, for the
+  environment being built. Use these for per-dataset endpoints rather than
+  hard-coding them.
+- **`rsp-data-table` directive** — render a table of which datasets expose
+  which data-access services (or a datasets × dataset-serving-environments
+  availability matrix) from discovery data, instead of hand-maintaining such
+  a list.
 - **Substitutions** (e.g. `|rsp-env|`, `|rsp-at|`) — env-specific words/phrases, defined in `rst_prolog.rst.jinja`. Code samples need the `:substitutions:` option to expand them.
 - **`rsp-only` directive** — include/exclude a block of content by environment or by service presence.
 - **`jinja` directive** — when a branch's text must be *computed* from environment data, not just shown or hidden.

--- a/conf.py
+++ b/conf.py
@@ -17,16 +17,19 @@ from rspdocs.sphinxext.services import excluded_page_patterns
 
 # Select the environment to build given the sphinx tag (-t on sphinx-build
 # CLI), defaulting to the primary env if no tag matches. Each sphinx-build
-# renders a single environment, so we only fetch that one -- plus the primary
-# env, which the docs always reference via ``all_envs.primary`` regardless of
-# which environment is being built.
+# renders a single environment (``rsp_env``), but we fetch every roster
+# environment so the cross-environment ``rsp-data-table`` (and any other
+# all-env construct) has data for the whole fleet, not just the target and
+# primary. The per-environment discovery JSON is small and disk-cached under
+# _build/discovery, so fetching all of it is cheap; the offline fallback still
+# applies per environment.
 _metadata = load_environments_metadata()
 target_env = PRIMARY_ENV
 for env_name in _metadata.build_roster:
     if env_name in tags:  # noqa: F405 F821
         target_env = env_name
         break
-_fetch_envs = list(dict.fromkeys([target_env, PRIMARY_ENV]))
+_fetch_envs = list(_metadata.build_roster)
 
 env_service = PhalanxEnvService.load(
     cache_dir=Path(__file__).parent / "_build" / "discovery",
@@ -50,10 +53,14 @@ extensions.append("sphinx_substitution_extensions")  # noqa: F405
 # Data channels the extension resolves roles/conditions against.
 rsp_all_envs = env_service.envs
 
-# Hash of the discovery JSON that was just loaded. Registered with
-# rebuild="env", this is the sole incremental-rebuild trigger: when discovery
-# data changes its hash changes, so Sphinx reparses every doc and the roles
-# re-bake fresh URLs into the doctrees.
+# Hash of the discovery JSON that was just loaded, over every fetched (roster)
+# environment. Registered with rebuild="env", this is the sole incremental-
+# rebuild trigger: when any environment's discovery data changes its hash
+# changes, so Sphinx reparses every doc and the roles and rsp-data-table
+# re-bake fresh URLs/availability into the doctrees. Hashing all roster
+# environments (not just the target and primary) keeps the cross-environment
+# rsp-data-table correct: a change to any environment's data invalidates the
+# build. _fetch_envs follows the ordered build roster, so the hash is stable.
 _discovery_hash = hashlib.sha256()
 for _name in _fetch_envs:
     _discovery_hash.update(

--- a/docs/contributing/env-specific-docs.rst
+++ b/docs/contributing/env-specific-docs.rst
@@ -20,6 +20,8 @@ This page describes the supported approaches for writing documentation that diff
 Reach for them in this order, from the most targeted to the most general:
 
 - :ref:`envdocs-roles` for inline URLs and links to RSP services.
+- :ref:`envdocs-dataset-roles` for inline URLs, links, and docs links tied to a specific dataset (for example a dataset's TAP endpoint).
+- :ref:`envdocs-data-table` for a table of which datasets expose which data-access services, rendered from discovery data.
 - :ref:`envdocs-substitutions` for env-specific words and short phrases that a role can't produce.
 - :ref:`envdocs-code-substitutions` for environment URLs inside code samples (``code-block`` and ``literalinclude``).
 - :ref:`envdocs-conditional` to include or exclude whole blocks of content per environment.
@@ -89,6 +91,75 @@ Some services aren't deployed in every environment; targeting a service that is 
    * - ``phalanx-docs``
      - Phalanx environment docs
      - yes
+
+.. _envdocs-dataset-roles:
+
+Linking to per-dataset services with roles
+==========================================
+
+The :ref:`roles above <envdocs-roles>` resolve an environment-wide service — the environment's single TAP endpoint, for example.
+Discovery also describes each service *per dataset*: which datasets (``dp1``, ``dp02``, ``dp03``, and so on) expose which data-access services, and at what URL.
+Three roles reach that dataset dimension so you don't hard-code a dataset's endpoint.
+
+``rsp-data-url``
+    ``:rsp-data-url:`service dataset``` renders a dataset's service URL as a code literal.
+    The target is exactly two tokens — a data-access service name and a dataset name — separated by a space.
+    For example, in the primary environment ``:rsp-data-url:`tap dp1``` renders as ``https://data.lsst.cloud/api/tap``.
+
+``rsp-data-link``
+    ``:rsp-data-link:`service dataset``` renders a hyperlink to that dataset's service, defaulting to the URL as its text, and accepts the familiar ``title <target>`` syntax.
+    For example, ``:rsp-data-link:`DP1 catalogs <tap dp1>``` renders as a link titled "DP1 catalogs" pointing at the dataset's TAP endpoint for the environment being built.
+
+``rsp-dataset-docs``
+    ``:rsp-dataset-docs:`dataset``` renders a hyperlink to a dataset's own documentation site (from discovery's ``docs_url``), also accepting a ``title <dataset>``.
+    For example, ``:rsp-dataset-docs:`Data Preview 1 <dp1>``` renders as a link titled "Data Preview 1" pointing at ``https://dp1.lsst.io/``.
+
+(The examples above show their primary-environment output as static text rather than rendering live, because no dataset is served in *every* environment — a live render would fail the builds for dataset-less environments, as described next.)
+
+The data-access service names are ``tap``, ``sia``, ``cutout``, ``datalink``, and ``hips``.
+Both URL roles accept a path after the dataset name — ``:rsp-data-url:`tap dp1/tables``` appends ``tables`` to the dataset's TAP URL — joined with the same slash-normalizing rules as the plain roles.
+
+A dataset can expose a service in one environment but not another (the same ``dp1`` offers SIA on the primary environment but not on every internal one), and some environments serve no datasets at all.
+Referencing a dataset or service that's absent in the environment being built — or a dataset with no ``docs_url`` — raises a warning (fatal under ``-W``), just like the plain roles.
+Wrap such references in a matching :ref:`rsp-only <envdocs-conditional>` block.
+Note that the per-dataset service names are **not** ``rsp-only`` condition tokens: only ``tap`` and ``api`` double as both.
+Gate on ``api`` (true wherever the environment serves datasets), on ``tap``, or on explicit environment names — and because the environment-level condition doesn't guarantee any particular dataset or per-dataset service, build the affected environments to confirm the guarded content resolves everywhere the condition holds.
+
+.. _envdocs-data-table:
+
+Tabulating dataset services with the ``rsp-data-table`` directive
+=================================================================
+
+To show which datasets expose which services — instead of hand-maintaining such a list — use the ``rsp-data-table`` directive, which renders a table from discovery data at build time:
+
+.. code-block:: rst
+
+   .. rsp-data-table::
+
+By default it produces one row per dataset served in the environment being built and one column per data-access service (TAP, SIA, cutout, datalink, HiPS), with each cell either a check mark linking to that dataset's service endpoint or an em dash where the service is absent.
+Datasets that expose none of the data-access services are omitted, and when no rows remain — notably in an environment that serves no datasets — the directive emits nothing at all.
+Even so, wrap it in a ``.. rsp-only:: api`` block so any surrounding lead-in prose is also dropped where the environment serves no datasets (see the :doc:`API aspect page </guides/api/index>`, which does exactly this).
+
+The directive takes a few options:
+
+``:services:``
+    A comma- or space-separated subset of the service tokens to use as columns (default: all five).
+    An unknown token warns (fatal under ``-W``).
+
+``:datasets:``
+    A subset of dataset names to use as rows (default: every dataset served in the environment).
+    An explicitly requested dataset is kept even when it exposes no data-access services, but a name that isn't served — in the environment being built (``env`` scope) or anywhere (``environments`` scope) — warns.
+
+``:scope:``
+    ``env`` (the default) tabulates datasets against services for the current environment, as above.
+    ``environments`` instead tabulates datasets against every environment *that serves datasets* (dataset-less environments get no column), marking where a single chosen service — set with ``:service:`` (default ``tap``) — is available for each dataset.
+    Use this cross-environment matrix to show, for example, which environments offer a dataset's TAP endpoint.
+
+``:service:``
+    The service the ``environments`` scope tabulates (default ``tap``); ignored in the default ``env`` scope.
+
+``:title:``
+    An optional table caption.
 
 .. _envdocs-substitutions:
 
@@ -238,7 +309,8 @@ As with any Sphinx directive, indent the content consistently with respect to th
 Two things to keep in mind:
 
 - For a simple two-way include/exclude, prefer :ref:`envdocs-conditional`: it reads more clearly and keeps excluded content out of search and the table of contents.
-- Each build fetches only the target environment and the primary environment (for speed), so ``all_envs`` holds just those one or two entries — a ``{% for %}`` loop over it will **not** enumerate all eight environments.
+- Each build fetches every roster environment, so ``all_envs`` holds all of them and a ``{% for %}`` loop over it enumerates the whole fleet.
+  ``env`` is still just the one environment being built, and ``all_envs.primary`` is the primary edition's environment.
 
 .. _envdocs-jinja-includes:
 

--- a/docs/guides/api/api.primary.in.rst
+++ b/docs/guides/api/api.primary.in.rst
@@ -19,6 +19,19 @@ These include the `Table Access Protocol <https://www.ivoa.net/documents/TAP/201
 
 By the time of the first data release, the Rubin Science Platform will also support the `Simple Cone Search (SCS) <https://www.ivoa.net/documents/latest/ConeSearch.html>`_ for basic catalog queries, and the `Virtual Observatory Space <https://www.ivoa.net/documents/VOSpace/>`_ (VOSpace)—alongside `Web Distributed Authoring and Versioning <https://en.wikipedia.org/wiki/WebDAV>`_ (WebDAV)—for user file access.
 
+.. rsp-only:: api
+
+   Data-access services by dataset
+   ===============================
+
+   The following table lists the data-access services each dataset exposes in |rsp-env|.
+   Not every dataset offers every service, and the same dataset can offer different services in different environments.
+   A check mark links directly to that dataset's service endpoint.
+
+   .. rsp-data-table::
+
+   These are the endpoint URLs to configure external clients such as `PyVO <https://pyvo.readthedocs.io/en/latest>`_ or `TOPCAT <https://www.star.bris.ac.uk/~mbt/topcat/>`_ with; see :doc:`/guides/auth/index` for the access token they require.
+
 
 Table Access Protocol (TAP) Service
 ===================================

--- a/src/rspdocs/discovery/models.py
+++ b/src/rspdocs/discovery/models.py
@@ -10,7 +10,12 @@ from rubin.repertoire import Discovery
 from ..constants import DOCS_ROOT_URL, PRIMARY_ENV
 from .metadata import EnvMeta
 
-__all__ = ["PhalanxEnv", "EnvironmentDict", "ltd_edition_url"]
+__all__ = [
+    "DatasetInfo",
+    "PhalanxEnv",
+    "EnvironmentDict",
+    "ltd_edition_url",
+]
 
 # Default ports we omit from a derived origin so it matches the URL as written
 # (pydantic always fills ``HttpUrl.port`` with the scheme default).
@@ -73,6 +78,64 @@ def _api_origin(discovery: Discovery) -> str:
     if fallback is None:  # pragma: no cover - datasets always expose services
         raise ValueError("discovery has datasets but no data services")
     return _origin(fallback)
+
+
+# User-facing data-access service tokens that a dataset may expose, in the
+# order they should appear in author-facing tables. Discovery also carries
+# per-dataset ``gms`` (group membership) and ``alerts`` services, but those are
+# not data-access endpoints users query for a dataset, so they are omitted.
+DATASET_SERVICES: tuple[str, ...] = (
+    "tap",
+    "sia",
+    "cutout",
+    "datalink",
+    "hips",
+)
+"""Dataset service tokens exposed to authors, in table-column order."""
+
+
+class DatasetInfo(BaseModel):
+    """A dataset available in an environment, with its data-access services.
+
+    Built from a Repertoire ``Dataset`` entry, this keeps only the
+    author-facing pieces: the dataset's description and documentation URL, and
+    the per-dataset data-access service URLs (TAP, SIA, cutout, datalink,
+    HiPS). A service token maps to ``None`` when the dataset does not expose it
+    in this environment.
+    """
+
+    name: str = Field(
+        description="The dataset's name (its discovery key).",
+        examples=["dp1"],
+    )
+
+    description: str | None = Field(
+        None,
+        description="Long description of the dataset.",
+        examples=["Data Preview 1 contains image and catalog products ..."],
+    )
+
+    docs_url: HttpUrl | None = Field(
+        None,
+        description="URL to more detailed documentation about the dataset.",
+        examples=["https://dp1.lsst.io/"],
+    )
+
+    services: dict[str, HttpUrl] = Field(
+        default_factory=dict,
+        description=(
+            "Data-access service token -> URL for the services this dataset "
+            "exposes. Only tokens in ``DATASET_SERVICES`` are retained."
+        ),
+    )
+
+    def service_url(self, service: str) -> HttpUrl | None:
+        """Return the URL for ``service`` in this dataset, or ``None``."""
+        return self.services.get(service)
+
+    def has_service(self, service: str) -> bool:
+        """Return whether this dataset exposes ``service``."""
+        return service in self.services
 
 
 class PhalanxEnv(BaseModel):
@@ -151,6 +214,15 @@ class PhalanxEnv(BaseModel):
         None,
         description="URL for root Times Square page (if deployed).",
         examples=["https://data.lsst.cloud/times-square/"],
+    )
+
+    datasets: dict[str, DatasetInfo] = Field(
+        default_factory=dict,
+        description=(
+            "Datasets served in this environment, keyed by dataset name, in "
+            "discovery order. Each carries its description, docs URL, and "
+            "per-dataset data-access service URLs."
+        ),
     )
 
     @classmethod
@@ -236,6 +308,22 @@ class PhalanxEnv(BaseModel):
             else None
         )
 
+        # Datasets and their user-facing data-access service URLs. Keep only
+        # the tokens in DATASET_SERVICES, preserving discovery's dataset order.
+        datasets: dict[str, DatasetInfo] = {}
+        for dataset_name, dataset in discovery.datasets.items():
+            services = {
+                token: dataset.services[token].url
+                for token in DATASET_SERVICES
+                if token in dataset.services
+            }
+            datasets[dataset_name] = DatasetInfo(
+                name=dataset_name,
+                description=dataset.description,
+                docs_url=dataset.docs_url,
+                services=services,
+            )
+
         return cls(
             name=name,
             title=meta.title,
@@ -252,6 +340,7 @@ class PhalanxEnv(BaseModel):
                 f"https://phalanx.lsst.io/environments/{name}/"
             ),
             times_square_url=times_square_url,
+            datasets=datasets,
         )
 
     @property

--- a/src/rspdocs/sphinxext/__init__.py
+++ b/src/rspdocs/sphinxext/__init__.py
@@ -6,12 +6,19 @@ The extension provides:
 * ``:rsp-url:`service``` -- a code literal of a service's URL (optionally
   with an appended path, as in ``:rsp-url:`rsp/settings```),
 * ``:rsp-link:`service``` -- an external hyperlink to a service (same
-  optional path syntax), and
+  optional path syntax),
+* ``:rsp-data-url:`service dataset``` / ``:rsp-data-link:`service dataset``` --
+  a code literal / hyperlink of a per-dataset data-access service URL (TAP,
+  SIA, cutout, datalink, HiPS), as in ``:rsp-data-url:`tap dp1```,
+* ``:rsp-dataset-docs:`dataset``` -- a link to a dataset's documentation,
+* ``.. rsp-data-table::`` -- a dataset/service availability matrix rendered
+  from discovery data, and
 * ``.. rsp-only::`` -- content included only in matching environments.
 
-All three resolve against the `~rspdocs.discovery.models.PhalanxEnv` for the
-environment being built, supplied through the ``rsp_env`` config value (see
-:file:`conf.py`).
+These resolve against the `~rspdocs.discovery.models.PhalanxEnv` for the
+environment being built, supplied through the ``rsp_env`` config value, and --
+for the cross-environment table -- against every roster environment supplied
+through ``rsp_all_envs`` (see :file:`conf.py`).
 """
 
 from __future__ import annotations
@@ -22,10 +29,17 @@ from typing import Any
 from sphinx.application import Sphinx
 from sphinx.errors import ConfigError
 
-from ..discovery.models import PhalanxEnv
+from ..discovery.models import DATASET_SERVICES, PhalanxEnv
 from .directives import RspOnly
-from .roles import RspLinkRole, RspUrlRole
-from .services import KNOWN_ENVS, SERVICE_ATTRS
+from .roles import (
+    RspDataLinkRole,
+    RspDatasetDocsRole,
+    RspDataUrlRole,
+    RspLinkRole,
+    RspUrlRole,
+)
+from .services import DATASET_SERVICE_LABELS, KNOWN_ENVS, SERVICE_ATTRS
+from .tables import RspDataTable
 
 __all__ = ["setup"]
 
@@ -58,9 +72,28 @@ def _check_token_namespaces_disjoint() -> None:
         )
 
 
+def _check_dataset_service_labels() -> None:
+    """Assert the dataset-service label map covers exactly the known tokens.
+
+    ``DATASET_SERVICE_LABELS`` supplies a display label for every per-dataset
+    service token; a token added to ``DATASET_SERVICES`` without a label (or a
+    stale label for a removed token) should fail the build loudly rather than
+    render a table with a missing or dangling column heading.
+    """
+    labelled = set(DATASET_SERVICE_LABELS)
+    known = set(DATASET_SERVICES)
+    if labelled != known:
+        raise ConfigError(
+            "rspdocs.sphinxext DATASET_SERVICE_LABELS must label exactly the "
+            f"DATASET_SERVICES tokens; missing {sorted(known - labelled)}, "
+            f"extra {sorted(labelled - known)}"
+        )
+
+
 def setup(app: Sphinx) -> dict[str, Any]:
     """Register the rspdocs roles, directive, and config values."""
     _check_token_namespaces_disjoint()
+    _check_dataset_service_labels()
 
     # Data channels for the current build. These are excluded from the ``env``
     # rebuild filter (rebuild="") so their pickled comparison never triggers a
@@ -78,7 +111,11 @@ def setup(app: Sphinx) -> dict[str, Any]:
 
     app.add_role("rsp-url", RspUrlRole())
     app.add_role("rsp-link", RspLinkRole())
+    app.add_role("rsp-data-url", RspDataUrlRole())
+    app.add_role("rsp-data-link", RspDataLinkRole())
+    app.add_role("rsp-dataset-docs", RspDatasetDocsRole())
     app.add_directive("rsp-only", RspOnly)
+    app.add_directive("rsp-data-table", RspDataTable)
 
     return {
         "version": version("rspdocs"),

--- a/src/rspdocs/sphinxext/logging.py
+++ b/src/rspdocs/sphinxext/logging.py
@@ -21,9 +21,19 @@ __all__ = [
     "UNKNOWN_SERVICE",
     "UNAVAILABLE_SERVICE",
     "UNKNOWN_CONDITION",
+    "UNKNOWN_DATASET_SERVICE",
+    "UNKNOWN_DATASET",
+    "UNAVAILABLE_DATASET",
+    "UNAVAILABLE_DATASET_DOCS",
+    "MALFORMED_DATASET_TARGET",
     "warn_unknown_service",
     "warn_unavailable_service",
     "warn_unknown_condition",
+    "warn_unknown_dataset_service",
+    "warn_unknown_dataset",
+    "warn_unavailable_dataset",
+    "warn_unavailable_dataset_docs",
+    "warn_malformed_dataset_target",
 ]
 
 logger = logging.getLogger(__name__)
@@ -39,6 +49,21 @@ UNAVAILABLE_SERVICE = "unavailable-service"
 
 UNKNOWN_CONDITION = "unknown-condition"
 """Subtype: an ``rsp-only`` token that isn't a service/env/``primary``."""
+
+UNKNOWN_DATASET_SERVICE = "unknown-dataset-service"
+"""Subtype: a dataset role targets an unknown per-dataset service token."""
+
+UNKNOWN_DATASET = "unknown-dataset"
+"""Subtype: an ``rsp-data-table`` ``:datasets:`` name that is not served."""
+
+UNAVAILABLE_DATASET = "unavailable-dataset"
+"""Subtype: a dataset role targets a dataset/service absent in this env."""
+
+UNAVAILABLE_DATASET_DOCS = "unavailable-dataset-docs"
+"""Subtype: a dataset-docs role targets a dataset with no docs URL here."""
+
+MALFORMED_DATASET_TARGET = "malformed-dataset-target"
+"""Subtype: a dataset role target isn't the ``service dataset`` form."""
 
 
 def warn_unknown_service(name: str, *, location: Any) -> None:
@@ -81,4 +106,87 @@ def warn_unknown_condition(token: str, *, location: Any) -> None:
         location=location,
         type=WARNING_TYPE,
         subtype=UNKNOWN_CONDITION,
+    )
+
+
+def warn_unknown_dataset_service(name: str, *, location: Any) -> None:
+    """Warn that ``name`` is not a recognized per-dataset service token."""
+    logger.warning(
+        "unknown dataset service %r; expected one of the documented "
+        "per-dataset service tokens (see "
+        "docs/contributing/env-specific-docs.rst)",
+        name,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=UNKNOWN_DATASET_SERVICE,
+    )
+
+
+def warn_unknown_dataset(name: str, where: str, *, location: Any) -> None:
+    """Warn that dataset ``name`` is not served in ``where``.
+
+    ``where`` is a human-readable scope, such as ``"the 'idfprod'
+    environment"`` or ``"any environment"``.
+    """
+    logger.warning(
+        "unknown dataset %r; it is not served in %s",
+        name,
+        where,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=UNKNOWN_DATASET,
+    )
+
+
+def warn_unavailable_dataset(
+    service: str, dataset: str, env_name: str, *, location: Any
+) -> None:
+    """Warn that ``service`` on ``dataset`` is absent in ``env_name``.
+
+    This usually means the reference should be wrapped in a matching
+    ``.. rsp-only::`` block (gated on ``api``, ``tap``, or environment names;
+    the per-dataset service tokens are not ``rsp-only`` conditions) so it is
+    only emitted where the dataset and service exist.
+    """
+    logger.warning(
+        "dataset %r does not expose the %r service in the %r environment; "
+        "wrap the reference in a matching '.. rsp-only::' block",
+        dataset,
+        service,
+        env_name,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=UNAVAILABLE_DATASET,
+    )
+
+
+def warn_unavailable_dataset_docs(
+    dataset: str, env_name: str, *, location: Any
+) -> None:
+    """Warn that no documentation URL exists for ``dataset`` in ``env_name``.
+
+    This covers both a dataset absent from the environment and one that is
+    served but whose discovery data carries no ``docs_url``.
+    """
+    logger.warning(
+        "no documentation URL for dataset %r in the %r environment (the "
+        "dataset is absent, or discovery reports no docs_url for it); wrap "
+        "the reference in a matching '.. rsp-only::' block",
+        dataset,
+        env_name,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=UNAVAILABLE_DATASET_DOCS,
+    )
+
+
+def warn_malformed_dataset_target(target: str, *, location: Any) -> None:
+    """Warn that ``target`` is not the ``service dataset`` form."""
+    logger.warning(
+        "malformed dataset reference %r; expected 'service dataset' (for "
+        "example 'tap dp1')",
+        target,
+        location=location,
+        type=WARNING_TYPE,
+        subtype=MALFORMED_DATASET_TARGET,
     )

--- a/src/rspdocs/sphinxext/roles.py
+++ b/src/rspdocs/sphinxext/roles.py
@@ -16,10 +16,31 @@ from __future__ import annotations
 from docutils import nodes
 from sphinx.util.docutils import ReferenceRole, SphinxRole
 
-from .logging import warn_unavailable_service, warn_unknown_service
-from .services import is_known_service, resolve_url, split_service_path
+from .logging import (
+    warn_malformed_dataset_target,
+    warn_unavailable_dataset,
+    warn_unavailable_dataset_docs,
+    warn_unavailable_service,
+    warn_unknown_dataset_service,
+    warn_unknown_service,
+)
+from .services import (
+    is_known_dataset_service,
+    is_known_service,
+    resolve_dataset_docs_url,
+    resolve_dataset_url,
+    resolve_url,
+    split_dataset_target,
+    split_service_path,
+)
 
-__all__ = ["RspUrlRole", "RspLinkRole"]
+__all__ = [
+    "RspUrlRole",
+    "RspLinkRole",
+    "RspDataUrlRole",
+    "RspDataLinkRole",
+    "RspDatasetDocsRole",
+]
 
 
 class RspUrlRole(SphinxRole):
@@ -58,6 +79,92 @@ class RspLinkRole(ReferenceRole):
         if url is None:
             warn_unavailable_service(
                 service, env.name, location=self.get_location()
+            )
+            return [nodes.Text(self.title)], []
+        display = self.title if self.has_explicit_title else url
+        node = nodes.reference("", display, refuri=url, internal=False)
+        return [node], []
+
+
+class RspDataUrlRole(SphinxRole):
+    """``:rsp-data-url:`service dataset[/path]``` -> a code literal.
+
+    Resolves a per-dataset data-access service URL (TAP, SIA, cutout,
+    datalink, HiPS) for the environment being built, as in
+    ``:rsp-data-url:`tap dp1```. An optional path may be appended to the
+    dataset name (``tap dp1/tables``), joined onto the service URL like
+    `~rspdocs.sphinxext.roles.RspUrlRole`. A malformed target, an unknown
+    service token, or a dataset/service absent from the environment warns
+    (fatal under ``-W``) and echoes the raw target.
+    """
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        service, dataset, path = split_dataset_target(self.text)
+        if not dataset:
+            warn_malformed_dataset_target(
+                self.text, location=self.get_location()
+            )
+            return [nodes.literal("", self.text)], []
+        if not is_known_dataset_service(service):
+            warn_unknown_dataset_service(service, location=self.get_location())
+            return [nodes.literal("", self.text)], []
+        env = self.config.rsp_env
+        url = resolve_dataset_url(env, service, dataset, path=path)
+        if url is None:
+            warn_unavailable_dataset(
+                service, dataset, env.name, location=self.get_location()
+            )
+            return [nodes.literal("", self.text)], []
+        return [nodes.literal("", url)], []
+
+
+class RspDataLinkRole(ReferenceRole):
+    """``:rsp-data-link:`service dataset[/path]``` -> an external hyperlink.
+
+    The hyperlink twin of ``:rsp-data-url:``. With no explicit title the link
+    text is the URL; ``:rsp-data-link:`Title <service dataset[/path]>``` uses
+    ``Title``.
+    """
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        service, dataset, path = split_dataset_target(self.target)
+        if not dataset:
+            warn_malformed_dataset_target(
+                self.target, location=self.get_location()
+            )
+            return [nodes.Text(self.title)], []
+        if not is_known_dataset_service(service):
+            warn_unknown_dataset_service(service, location=self.get_location())
+            return [nodes.Text(self.title)], []
+        env = self.config.rsp_env
+        url = resolve_dataset_url(env, service, dataset, path=path)
+        if url is None:
+            warn_unavailable_dataset(
+                service, dataset, env.name, location=self.get_location()
+            )
+            return [nodes.Text(self.title)], []
+        display = self.title if self.has_explicit_title else url
+        node = nodes.reference("", display, refuri=url, internal=False)
+        return [node], []
+
+
+class RspDatasetDocsRole(ReferenceRole):
+    """``:rsp-dataset-docs:`dataset``` -> a link to the dataset's docs.
+
+    Resolves a dataset's ``docs_url`` from discovery for the environment being
+    built, as in ``:rsp-dataset-docs:`dp1```. With no explicit title the link
+    text is the URL; ``:rsp-dataset-docs:`Title <dataset>``` uses ``Title``. A
+    dataset absent from the environment, or one whose discovery data carries no
+    ``docs_url``, warns (fatal under ``-W``) and falls back to the title text.
+    """
+
+    def run(self) -> tuple[list[nodes.Node], list[nodes.system_message]]:
+        dataset = self.target.strip()
+        env = self.config.rsp_env
+        url = resolve_dataset_docs_url(env, dataset)
+        if url is None:
+            warn_unavailable_dataset_docs(
+                dataset, env.name, location=self.get_location()
             )
             return [nodes.Text(self.title)], []
         display = self.title if self.has_explicit_title else url

--- a/src/rspdocs/sphinxext/services.py
+++ b/src/rspdocs/sphinxext/services.py
@@ -22,15 +22,20 @@ from importlib.resources import files
 import yaml
 
 from ..discovery.metadata import load_environments_metadata
-from ..discovery.models import PhalanxEnv
+from ..discovery.models import DATASET_SERVICES, PhalanxEnv
 
 __all__ = [
     "SERVICE_ATTRS",
     "SERVICE_PAGE_EXCLUDES",
+    "DATASET_SERVICE_LABELS",
     "KNOWN_ENVS",
     "is_known_service",
+    "is_known_dataset_service",
     "split_service_path",
+    "split_dataset_target",
     "resolve_url",
+    "resolve_dataset_url",
+    "resolve_dataset_docs_url",
     "is_available",
     "resolve_condition",
     "excluded_page_patterns",
@@ -50,6 +55,46 @@ SERVICE_ATTRS: dict[str, str] = {
     "phalanx-docs": "phalanx_docs_url",
 }
 """Canonical service token -> `PhalanxEnv` attribute holding its URL."""
+
+DATASET_SERVICE_LABELS: dict[str, str] = {
+    "tap": "TAP",
+    "sia": "SIA",
+    "cutout": "Cutout (SODA)",
+    "datalink": "DataLink",
+    "hips": "HiPS",
+}
+"""Dataset service token -> display label for author-facing tables.
+
+Its keys are exactly ``DATASET_SERVICES`` (order-preserving); a guard in
+`~rspdocs.sphinxext.setup` asserts the two stay in sync.
+"""
+
+
+def is_known_dataset_service(name: str) -> bool:
+    """Return whether ``name`` is a recognized per-dataset service token."""
+    return name in DATASET_SERVICES
+
+
+def split_dataset_target(target: str) -> tuple[str, str, str]:
+    """Split a ``:rsp-data-url:`` target into service, dataset, and path.
+
+    The target syntax is ``service dataset[/path]``: exactly two
+    whitespace-separated tokens — a service token and a dataset name — where
+    the dataset name may carry an appended ``/path`` joined onto the dataset's
+    service URL exactly as `split_service_path` does for plain services. The
+    two tokens may be separated by any amount of whitespace, but a target with
+    more (or fewer) than two tokens is malformed.
+
+    Returns a ``(service, dataset, path)`` tuple. A malformed target yields an
+    empty dataset (and empty path), which callers report as a malformed
+    reference.
+    """
+    parts = target.split()
+    service = parts[0] if parts else ""
+    if len(parts) != 2:
+        return service, "", ""
+    dataset, path = split_service_path(parts[1])
+    return service, dataset, path
 
 
 def _load_service_page_excludes() -> dict[str, list[str]]:
@@ -138,6 +183,42 @@ def resolve_url(env: PhalanxEnv, name: str, path: str = "") -> str | None:
     if not path:
         return base
     return f"{base.rstrip('/')}/{path.lstrip('/')}"
+
+
+def resolve_dataset_url(
+    env: PhalanxEnv, service: str, dataset: str, path: str = ""
+) -> str | None:
+    """Return the URL for ``service`` on ``dataset`` in ``env``, or ``None``.
+
+    ``None`` is returned when the dataset is absent from this environment or
+    when it does not expose that service; callers that need to tell an unknown
+    service token apart from an absent dataset/service should check
+    `is_known_dataset_service` first. A non-empty ``path`` is appended to the
+    dataset's service URL with the same slash-normalizing join as
+    `resolve_url`.
+    """
+    dataset_info = env.datasets.get(dataset)
+    if dataset_info is None:
+        return None
+    url = dataset_info.service_url(service)
+    if url is None:
+        return None
+    base = str(url)
+    if not path:
+        return base
+    return f"{base.rstrip('/')}/{path.lstrip('/')}"
+
+
+def resolve_dataset_docs_url(env: PhalanxEnv, dataset: str) -> str | None:
+    """Return the documentation URL for ``dataset`` in ``env``, or ``None``.
+
+    ``None`` is returned when the dataset is absent from this environment or
+    when discovery reports no ``docs_url`` for it.
+    """
+    dataset_info = env.datasets.get(dataset)
+    if dataset_info is None or dataset_info.docs_url is None:
+        return None
+    return str(dataset_info.docs_url)
 
 
 def is_available(env: PhalanxEnv, name: str) -> bool:

--- a/src/rspdocs/sphinxext/tables.py
+++ b/src/rspdocs/sphinxext/tables.py
@@ -1,0 +1,234 @@
+"""The ``rsp-data-table`` directive: dataset/service availability matrices.
+
+The directive renders a table from Repertoire discovery data at build time, so
+authors don't hand-maintain which datasets expose which data-access services.
+It has two shapes, chosen by the ``:scope:`` option:
+
+* ``:scope: env`` (the default) -- one row per dataset served in the
+  environment being built (omitting datasets that expose none of the
+  data-access services), one column per data-access service (TAP, SIA, cutout,
+  datalink, HiPS), each cell a check-mark linking to that dataset's service
+  URL. This answers "which services can I use for each dataset here?".
+* ``:scope: environments`` -- one row per dataset, one column per roster
+  environment *that serves datasets* (dataset-less environments get no
+  column), each cell marking whether a chosen ``:service:`` (default ``tap``)
+  is available for that dataset in that environment. This answers "where is
+  this dataset's TAP service deployed?" and needs discovery data for every
+  roster environment, supplied through the ``rsp_all_envs`` config value.
+
+A ``:services:`` option narrows the ``env`` scope to a subset of service
+columns; a ``:datasets:`` option narrows either scope to a subset of dataset
+rows. Unknown tokens or dataset names warn (fatal under ``-W``). When no
+dataset rows remain -- notably in an environment that serves no datasets --
+the directive emits nothing rather than a header-only table.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from docutils import nodes
+from docutils.parsers.rst import directives
+from sphinx.util.docutils import SphinxDirective
+
+from ..discovery.models import DATASET_SERVICES, PhalanxEnv
+from .logging import warn_unknown_dataset, warn_unknown_dataset_service
+from .services import DATASET_SERVICE_LABELS, resolve_dataset_url
+
+__all__ = ["RspDataTable"]
+
+_CHECK = "✓"  # check mark for an available service
+_DASH = "—"  # em dash for an absent one
+
+
+def _tokens(raw: str | None) -> list[str]:
+    """Split a comma/whitespace option value into a list of tokens."""
+    if not raw:
+        return []
+    return raw.replace(",", " ").split()
+
+
+class RspDataTable(SphinxDirective):
+    """Render a dataset/service availability table from discovery data."""
+
+    has_content = False
+    option_spec = {
+        "scope": lambda a: directives.choice(a, ("env", "environments")),
+        "service": directives.unchanged,
+        "services": directives.unchanged,
+        "datasets": directives.unchanged,
+        "title": directives.unchanged,
+    }
+
+    def run(self) -> list[nodes.Node]:
+        scope = self.options.get("scope", "env")
+        if scope == "environments":
+            return self._run_environments()
+        return self._run_env()
+
+    # -- helpers ----------------------------------------------------------
+
+    def _service_columns(self) -> list[str]:
+        """Return the dataset-service tokens to use as columns."""
+        requested = _tokens(self.options.get("services"))
+        if not requested:
+            return list(DATASET_SERVICES)
+        columns: list[str] = []
+        for token in requested:
+            if token not in DATASET_SERVICES:
+                warn_unknown_dataset_service(
+                    token, location=self.get_location()
+                )
+                continue
+            columns.append(token)
+        return columns
+
+    def _dataset_rows(self, env: PhalanxEnv) -> list[str]:
+        """Return the dataset names to use as rows, in discovery order.
+
+        By default, datasets that expose none of the data-access services are
+        omitted (they would render an all-dash row). An explicit ``:datasets:``
+        request keeps such datasets, but a requested name that is not served
+        in this environment warns and is dropped.
+        """
+        requested = _tokens(self.options.get("datasets"))
+        if not requested:
+            return [
+                name for name, info in env.datasets.items() if info.services
+            ]
+        # Preserve the requested order; warn on names not served here.
+        rows: list[str] = []
+        for name in requested:
+            if name not in env.datasets:
+                warn_unknown_dataset(
+                    name,
+                    f"the {env.name!r} environment",
+                    location=self.get_location(),
+                )
+                continue
+            rows.append(name)
+        return rows
+
+    def _all_dataset_names(self, envs: Sequence[PhalanxEnv]) -> list[str]:
+        """Return dataset names across ``envs``, discovery order, de-duped.
+
+        A ``:datasets:`` request preserves its own order; a requested name
+        served in none of the environments warns and is dropped.
+        """
+        served: list[str] = []
+        for env in envs:
+            for name in env.datasets:
+                if name not in served:
+                    served.append(name)
+        requested = _tokens(self.options.get("datasets"))
+        if not requested:
+            return served
+        names: list[str] = []
+        for name in requested:
+            if name not in served:
+                warn_unknown_dataset(
+                    name, "any environment", location=self.get_location()
+                )
+                continue
+            names.append(name)
+        return names
+
+    @staticmethod
+    def _build_table(
+        headers: Sequence[str],
+        rows: Sequence[Sequence[nodes.Node]],
+        *,
+        title: str | None,
+    ) -> nodes.table:
+        """Assemble a docutils table node from header/row content nodes."""
+        table = nodes.table()
+        if title:
+            table += nodes.title("", title)
+        tgroup = nodes.tgroup(cols=len(headers))
+        table += tgroup
+        for _ in headers:
+            tgroup += nodes.colspec(colwidth=1)
+        thead = nodes.thead()
+        tgroup += thead
+        header_row = nodes.row()
+        for label in headers:
+            entry = nodes.entry()
+            entry += nodes.paragraph("", "", nodes.Text(label))
+            header_row += entry
+        thead += header_row
+        tbody = nodes.tbody()
+        tgroup += tbody
+        for row in rows:
+            table_row = nodes.row()
+            for cell in row:
+                entry = nodes.entry()
+                entry += cell
+                table_row += entry
+            tbody += table_row
+        return table
+
+    @staticmethod
+    def _cell(content: nodes.Node) -> nodes.paragraph:
+        """Wrap inline content in a paragraph for a table cell."""
+        para = nodes.paragraph()
+        para += content
+        return para
+
+    def _link_or_mark(self, url: str | None) -> nodes.paragraph:
+        """A linked check-mark when ``url`` is set, else a plain em dash."""
+        if url is None:
+            return self._cell(nodes.Text(_DASH))
+        ref = nodes.reference("", _CHECK, refuri=url, internal=False)
+        return self._cell(ref)
+
+    # -- scope: env -------------------------------------------------------
+
+    def _run_env(self) -> list[nodes.Node]:
+        env: PhalanxEnv = self.config.rsp_env
+        columns = self._service_columns()
+        datasets = self._dataset_rows(env)
+        if not datasets:
+            # No rows (for example, an environment serving no datasets):
+            # emit nothing rather than a header-only table.
+            return []
+        headers = ["Dataset"] + [
+            DATASET_SERVICE_LABELS[token] for token in columns
+        ]
+        rows: list[list[nodes.Node]] = []
+        for dataset in datasets:
+            cells: list[nodes.Node] = [self._cell(nodes.literal("", dataset))]
+            for token in columns:
+                url = resolve_dataset_url(env, token, dataset)
+                cells.append(self._link_or_mark(url))
+            rows.append(cells)
+        title = self.options.get("title")
+        return [self._build_table(headers, rows, title=title)]
+
+    # -- scope: environments ----------------------------------------------
+
+    def _run_environments(self) -> list[nodes.Node]:
+        all_envs: dict[str, PhalanxEnv] = self.config.rsp_all_envs or {}
+        # Only environments that serve at least one dataset are worth a column.
+        envs = [env for env in all_envs.values() if env.datasets]
+        service = self.options.get("service", "tap")
+        if service not in DATASET_SERVICES:
+            warn_unknown_dataset_service(service, location=self.get_location())
+            service = "tap"
+        datasets = self._all_dataset_names(envs)
+        if not datasets:
+            # No dataset rows anywhere in the fleet: emit nothing.
+            return []
+        # Column headings use the human-readable environment title.
+        headers = ["Dataset"] + [env.title for env in envs]
+        rows: list[list[nodes.Node]] = []
+        for dataset in datasets:
+            cells: list[nodes.Node] = [self._cell(nodes.literal("", dataset))]
+            for env in envs:
+                url = resolve_dataset_url(env, service, dataset)
+                cells.append(self._link_or_mark(url))
+            rows.append(cells)
+        title = self.options.get(
+            "title",
+            f"{DATASET_SERVICE_LABELS[service]} service availability",
+        )
+        return [self._build_table(headers, rows, title=title)]

--- a/styles/config/vocabularies/RSP/accept.txt
+++ b/styles/config/vocabularies/RSP/accept.txt
@@ -26,6 +26,8 @@ Stefani
 coadd
 coadded
 dayobs
+[Dd]ata[Ll]ink
+dataset's
 
 # --- Software / tooling terms -----------------------------------------------
 APIs?

--- a/tests/discovery/test_mapping.py
+++ b/tests/discovery/test_mapping.py
@@ -182,3 +182,67 @@ def test_non_primary_env_ltd_url(discovery_data_dir: Path) -> None:
 
     assert env.is_primary is False
     assert env.ltd_url_prefix == "https://rsp.lsst.io/v/summit/"
+
+
+def test_datasets_mapped(discovery_data_dir: Path) -> None:
+    """Datasets and their user-facing service URLs map from discovery.
+
+    Discovery order is preserved, and only the user-facing data-access service
+    tokens (TAP, SIA, cutout, datalink, HiPS) are retained -- the per-dataset
+    ``gms`` and ``alerts`` services are dropped.
+    """
+    discovery = _load("idfprod", discovery_data_dir)
+    meta = EnvMeta(title="data.lsst.cloud")
+
+    env = PhalanxEnv.from_discovery(discovery, name="idfprod", meta=meta)
+
+    assert list(env.datasets) == ["dp02", "dp03", "dp1", "prompt"]
+    dp1 = env.datasets["dp1"]
+    assert dp1.name == "dp1"
+    assert dp1.description is not None
+    assert str(dp1.docs_url) == "https://dp1.lsst.io/"
+    # The user-facing data-access services, and nothing else (no gms).
+    assert set(dp1.services) == {"tap", "sia", "cutout", "datalink", "hips"}
+    assert str(dp1.service_url("tap")) == "https://data.lsst.cloud/api/tap"
+    assert dp1.has_service("sia")
+    # dp03 exposes only TAP (per discovery), so SIA is absent.
+    dp03 = env.datasets["dp03"]
+    assert set(dp03.services) == {"tap"}
+    assert not dp03.has_service("sia")
+    assert dp03.service_url("sia") is None
+    # The prompt dataset exposes only non-user-facing services (gms/alerts),
+    # so it maps to an empty service set but keeps its metadata.
+    assert env.datasets["prompt"].services == {}
+
+
+def test_datasets_absent_without_data(discovery_data_dir: Path) -> None:
+    """An environment serving no datasets has an empty ``datasets`` map."""
+    discovery = _load("base", discovery_data_dir)
+    meta = EnvMeta(title="Rubin Base Data Facility")
+
+    env = PhalanxEnv.from_discovery(discovery, name="base", meta=meta)
+
+    assert env.datasets == {}
+
+
+def test_dataset_services_differ_across_envs(
+    discovery_data_dir: Path,
+) -> None:
+    """A dataset can expose different services in different environments.
+
+    dp1 exposes SIA and cutout on idfprod but not on usdfprod, so the roles
+    and tables must resolve against the environment being built.
+    """
+    idfprod = PhalanxEnv.from_discovery(
+        _load("idfprod", discovery_data_dir),
+        name="idfprod",
+        meta=EnvMeta(title="idfprod"),
+    )
+    usdfprod = PhalanxEnv.from_discovery(
+        _load("usdfprod", discovery_data_dir),
+        name="usdfprod",
+        meta=EnvMeta(title="usdfprod"),
+    )
+
+    assert idfprod.datasets["dp1"].has_service("sia")
+    assert not usdfprod.datasets["dp1"].has_service("sia")

--- a/tests/sphinxext/test_roles.py
+++ b/tests/sphinxext/test_roles.py
@@ -132,3 +132,143 @@ def test_role_warning_is_suppressible(
     )
     parse(app, ":rsp-link:`tap`")
     assert app.warning.getvalue() == ""
+
+
+# -- Dataset-aware roles --------------------------------------------------
+
+
+def test_rsp_data_url_emits_literal(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """``:rsp-data-url:`tap dp1``` renders the dataset TAP URL as a literal."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-data-url:`tap dp1`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "https://data.lsst.cloud/api/tap"
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_data_url_with_path(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A path after the dataset joins onto the dataset service URL."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-data-url:`tap dp1/tables`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "https://data.lsst.cloud/api/tap/tables"
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_data_link_default_and_titled(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """The link twin defaults to the URL and honors an explicit title."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-data-link:`sia dp1`")
+    ref = doctree.next_node(nodes.reference)
+    assert isinstance(ref, nodes.reference)
+    assert ref["refuri"] == "https://data.lsst.cloud/api/sia/dp1"
+    assert ref.astext() == "https://data.lsst.cloud/api/sia/dp1"
+    assert ref.get("internal") is False
+
+    titled = parse(app, ":rsp-data-link:`DP1 images <sia dp1>`")
+    ref2 = titled.next_node(nodes.reference)
+    assert isinstance(ref2, nodes.reference)
+    assert ref2.astext() == "DP1 images"
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_data_url_malformed_target_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A target missing the dataset half warns and echoes the raw text."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-data-url:`tap`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "tap"
+    assert "malformed-dataset-target" in app.warning.getvalue()
+
+
+def test_rsp_data_url_extra_tokens_warn(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A target with more than two tokens is malformed, not truncated."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-data-url:`tap dp1 tables`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "tap dp1 tables"
+    assert "malformed-dataset-target" in app.warning.getvalue()
+
+
+def test_rsp_data_url_unknown_service_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A non-dataset service token warns as unknown-dataset-service."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-data-url:`gms dp1`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "gms dp1"
+    assert "unknown-dataset-service" in app.warning.getvalue()
+
+
+def test_rsp_data_url_unavailable_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A dataset that doesn't expose the service warns (fatal under -W)."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    # dp03 exposes only TAP, so SIA is unavailable.
+    doctree = parse(app, ":rsp-data-url:`sia dp03`")
+    literal = doctree.next_node(nodes.literal)
+    assert isinstance(literal, nodes.literal)
+    assert literal.astext() == "sia dp03"
+    assert "unavailable-dataset" in app.warning.getvalue()
+
+
+def test_rsp_data_link_absent_dataset_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A dataset absent from the environment warns and emits no link."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-data-link:`tap nope`")
+    assert doctree.next_node(nodes.reference) is None
+    assert "unavailable-dataset" in app.warning.getvalue()
+
+
+def test_rsp_dataset_docs_resolves(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """``:rsp-dataset-docs:`dp1``` links to the dataset's docs_url."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-dataset-docs:`dp1`")
+    ref = doctree.next_node(nodes.reference)
+    assert isinstance(ref, nodes.reference)
+    assert ref["refuri"] == "https://dp1.lsst.io/"
+
+    titled = parse(app, ":rsp-dataset-docs:`Data Preview 1 <dp1>`")
+    ref2 = titled.next_node(nodes.reference)
+    assert isinstance(ref2, nodes.reference)
+    assert ref2.astext() == "Data Preview 1"
+    assert app.warning.getvalue() == ""
+
+
+def test_rsp_dataset_docs_missing_url_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A dataset without a docs_url warns and falls back to the title.
+
+    The warning is the dedicated docs subtype with an accurate message, not
+    the generic unavailable-dataset one (which would misleadingly call
+    ``docs`` a service the dataset fails to expose).
+    """
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    doctree = parse(app, ":rsp-dataset-docs:`Prompt <prompt>`")
+    assert doctree.next_node(nodes.reference) is None
+    assert doctree.astext().strip() == "Prompt"
+    warnings = app.warning.getvalue()
+    assert "unavailable-dataset-docs" in warnings
+    assert "no documentation URL for dataset 'prompt'" in warnings

--- a/tests/sphinxext/test_services.py
+++ b/tests/sphinxext/test_services.py
@@ -9,9 +9,13 @@ from rspdocs.sphinxext.services import (
     SERVICE_PAGE_EXCLUDES,
     excluded_page_patterns,
     is_available,
+    is_known_dataset_service,
     is_known_service,
     resolve_condition,
+    resolve_dataset_docs_url,
+    resolve_dataset_url,
     resolve_url,
+    split_dataset_target,
     split_service_path,
 )
 
@@ -143,6 +147,66 @@ def test_excluded_page_patterns_absent_services(make_env: MakeEnv) -> None:
 def test_excluded_page_patterns_full_env(make_env: MakeEnv) -> None:
     """A fully-featured env (idfint) excludes nothing."""
     assert excluded_page_patterns(make_env("idfint")) == []
+
+
+def test_is_known_dataset_service() -> None:
+    """Dataset service tokens are recognized; plain services aren't."""
+    assert is_known_dataset_service("tap")
+    assert is_known_dataset_service("sia")
+    assert is_known_dataset_service("hips")
+    assert not is_known_dataset_service("gms")  # not user-facing
+    assert not is_known_dataset_service("portal")  # a UI service
+    assert not is_known_dataset_service("bogus")
+
+
+def test_split_dataset_target() -> None:
+    """A dataset target splits into (service, dataset, path)."""
+    assert split_dataset_target("tap dp1") == ("tap", "dp1", "")
+    assert split_dataset_target("tap dp1/tables") == ("tap", "dp1", "tables")
+    # Any amount of whitespace may separate the two tokens.
+    assert split_dataset_target("sia   dp02") == ("sia", "dp02", "")
+    # A single token yields no dataset (malformed).
+    assert split_dataset_target("tap") == ("tap", "", "")
+    assert split_dataset_target("") == ("", "", "")
+    # More than two tokens is malformed too, not silently truncated.
+    assert split_dataset_target("tap dp1 tables") == ("tap", "", "")
+
+
+def test_resolve_dataset_url_present(make_env: MakeEnv) -> None:
+    """A dataset's service resolves to its exact URL, with optional path."""
+    env = make_env("idfprod", hidden_services=["times-square"])
+    assert (
+        resolve_dataset_url(env, "tap", "dp1")
+        == "https://data.lsst.cloud/api/tap"
+    )
+    assert resolve_dataset_url(env, "tap", "dp1", path="tables") == (
+        "https://data.lsst.cloud/api/tap/tables"
+    )
+    # A leading slash on the path is normalized, not host-root-resolved.
+    assert resolve_dataset_url(env, "tap", "dp1", path="/tables") == (
+        "https://data.lsst.cloud/api/tap/tables"
+    )
+
+
+def test_resolve_dataset_url_absent(make_env: MakeEnv) -> None:
+    """Absent datasets, absent services, and unknown datasets are None."""
+    env = make_env("idfprod", hidden_services=["times-square"])
+    # dp03 exposes only TAP, so SIA is absent.
+    assert resolve_dataset_url(env, "sia", "dp03") is None
+    # An unknown dataset name resolves to None.
+    assert resolve_dataset_url(env, "tap", "nope") is None
+    # An environment without datasets has nothing to resolve.
+    assert resolve_dataset_url(make_env("base"), "tap", "dp1") is None
+
+
+def test_resolve_dataset_docs_url(make_env: MakeEnv) -> None:
+    """A dataset's docs_url resolves, or None when absent/unset."""
+    env = make_env("idfprod", hidden_services=["times-square"])
+    assert resolve_dataset_docs_url(env, "dp1") == "https://dp1.lsst.io/"
+    # The prompt dataset has no docs_url in discovery.
+    assert resolve_dataset_docs_url(env, "prompt") is None
+    # An unknown dataset resolves to None.
+    assert resolve_dataset_docs_url(env, "nope") is None
 
 
 def test_excluded_page_patterns_hidden_service(make_env: MakeEnv) -> None:

--- a/tests/sphinxext/test_tables.py
+++ b/tests/sphinxext/test_tables.py
@@ -1,0 +1,227 @@
+"""Doctree tests for the ``rsp-data-table`` directive."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+
+from docutils import nodes
+from sphinx.testing.restructuredtext import parse
+from sphinx.testing.util import SphinxTestApp
+
+from rspdocs.discovery.models import PhalanxEnv
+
+MakeEnv = Callable[..., PhalanxEnv]
+AppFactory = Callable[..., SphinxTestApp]
+
+
+def _table(doctree: nodes.document) -> nodes.table:
+    return next(iter(doctree.findall(nodes.table)))
+
+
+def _headers(table: nodes.table) -> list[str]:
+    thead = next(iter(table.findall(nodes.thead)))
+    row = next(iter(thead.findall(nodes.row)))
+    return [entry.astext() for entry in row.findall(nodes.entry)]
+
+
+def _body_rows(table: nodes.table) -> list[list[str]]:
+    tbody = next(iter(table.findall(nodes.tbody)))
+    return [
+        [entry.astext() for entry in row.findall(nodes.entry)]
+        for row in tbody.findall(nodes.row)
+    ]
+
+
+def test_env_scope_columns_are_services(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """The default scope has one column per data-access service."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    table = _table(parse(app, ".. rsp-data-table::"))
+    assert _headers(table) == [
+        "Dataset",
+        "TAP",
+        "SIA",
+        "Cutout (SODA)",
+        "DataLink",
+        "HiPS",
+    ]
+    rows = _body_rows(table)
+    # One row per dataset served in idfprod, in discovery order. ``prompt``
+    # exposes none of the data-access services, so it is omitted by default.
+    assert [row[0] for row in rows] == ["dp02", "dp03", "dp1"]
+    # dp1 exposes every service (a check mark in each cell).
+    dp1 = next(row for row in rows if row[0] == "dp1")
+    assert dp1[1:] == ["✓", "✓", "✓", "✓", "✓"]
+    # dp03 exposes only TAP; the rest are em dashes.
+    dp03 = next(row for row in rows if row[0] == "dp03")
+    assert dp03[1:] == ["✓", "—", "—", "—", "—"]
+    assert app.warning.getvalue() == ""
+
+
+def test_env_scope_links_to_service_urls(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """Each available cell links to that dataset's service URL."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    table = _table(parse(app, ".. rsp-data-table::"))
+    refs = [r["refuri"] for r in table.findall(nodes.reference)]
+    assert "https://data.lsst.cloud/api/tap" in refs
+    assert "https://data.lsst.cloud/api/sia/dp1" in refs
+
+
+def test_env_scope_services_option_narrows_columns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """The ``:services:`` option restricts the service columns."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    table = _table(parse(app, ".. rsp-data-table::\n   :services: tap, sia\n"))
+    assert _headers(table) == ["Dataset", "TAP", "SIA"]
+    assert app.warning.getvalue() == ""
+
+
+def test_env_scope_datasets_option_narrows_rows(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """The ``:datasets:`` option restricts the dataset rows."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    table = _table(parse(app, ".. rsp-data-table::\n   :datasets: dp1\n"))
+    assert [row[0] for row in _body_rows(table)] == ["dp1"]
+
+
+def test_env_scope_explicit_dataset_without_services(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """An explicitly requested dataset is kept even with no services.
+
+    ``prompt`` is omitted from the default rows (it exposes none of the
+    data-access services), but naming it in ``:datasets:`` includes it as an
+    all-dash row without warning.
+    """
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    table = _table(parse(app, ".. rsp-data-table::\n   :datasets: prompt\n"))
+    rows = _body_rows(table)
+    assert [row[0] for row in rows] == ["prompt"]
+    assert rows[0][1:] == ["—", "—", "—", "—", "—"]
+    assert app.warning.getvalue() == ""
+
+
+def test_env_scope_no_datasets_emits_nothing(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """An environment serving no datasets renders no table at all."""
+    app = app_factory(make_env("base"))
+    doctree = parse(app, ".. rsp-data-table::")
+    assert next(iter(doctree.findall(nodes.table)), None) is None
+    assert app.warning.getvalue() == ""
+
+
+def test_env_scope_unknown_dataset_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A ``:datasets:`` name not served in this environment warns."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    table = _table(
+        parse(app, ".. rsp-data-table::\n   :datasets: dp1 bogus\n")
+    )
+    assert [row[0] for row in _body_rows(table)] == ["dp1"]
+    assert "unknown-dataset" in app.warning.getvalue()
+
+
+def test_unknown_service_column_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """An unknown ``:services:`` token warns and is dropped from the table."""
+    app = app_factory(make_env("idfprod", hidden_services=["times-square"]))
+    table = _table(
+        parse(app, ".. rsp-data-table::\n   :services: tap bogus\n")
+    )
+    assert _headers(table) == ["Dataset", "TAP"]
+    assert "unknown-dataset-service" in app.warning.getvalue()
+
+
+def test_environments_scope_matrix(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """The ``environments`` scope makes columns of dataset-serving envs."""
+    envs = {
+        name: make_env(name, hidden_services=["times-square"])
+        for name in ("idfprod", "usdfprod", "base")
+    }
+    app = app_factory(envs["idfprod"], all_envs=envs)
+    table = _table(
+        parse(app, ".. rsp-data-table::\n   :scope: environments\n")
+    )
+    headers = _headers(table)
+    # base serves no datasets, so it is not a column; idfprod/usdfprod are.
+    # Columns are labelled with env.title (the make_env fixture titles each
+    # environment with its name).
+    assert headers == ["Dataset", "idfprod", "usdfprod"]
+    rows = _body_rows(table)
+    # dp1 has TAP in both idfprod and usdfprod.
+    dp1 = next(row for row in rows if row[0] == "dp1")
+    assert dp1 == ["dp1", "✓", "✓"]
+    assert app.warning.getvalue() == ""
+
+
+def test_environments_scope_service_option(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """The ``:service:`` option chooses which service the matrix shows.
+
+    dp1 exposes SIA on idfprod but not on usdfprod, so the SIA matrix differs
+    across the two environment columns.
+    """
+    envs = {
+        name: make_env(name, hidden_services=["times-square"])
+        for name in ("idfprod", "usdfprod")
+    }
+    app = app_factory(envs["idfprod"], all_envs=envs)
+    table = _table(
+        parse(
+            app,
+            ".. rsp-data-table::\n   :scope: environments\n   :service: sia\n",
+        )
+    )
+    rows = _body_rows(table)
+    dp1 = next(row for row in rows if row[0] == "dp1")
+    # SIA present on idfprod, absent on usdfprod.
+    assert dp1 == ["dp1", "✓", "—"]
+    assert app.warning.getvalue() == ""
+
+
+def test_environments_scope_unknown_dataset_warns(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """A ``:datasets:`` name served in no environment warns and is dropped."""
+    envs = {
+        name: make_env(name, hidden_services=["times-square"])
+        for name in ("idfprod", "usdfprod")
+    }
+    app = app_factory(envs["idfprod"], all_envs=envs)
+    table = _table(
+        parse(
+            app,
+            ".. rsp-data-table::\n"
+            "   :scope: environments\n"
+            "   :datasets: dp1 bogus\n",
+        )
+    )
+    assert [row[0] for row in _body_rows(table)] == ["dp1"]
+    warnings = app.warning.getvalue()
+    assert "unknown-dataset" in warnings
+    assert "any environment" in warnings
+
+
+def test_environments_scope_column_titles(
+    make_env: MakeEnv, app_factory: AppFactory
+) -> None:
+    """Environment columns are labelled with env.title, not env.name."""
+    env = make_env("idfprod", hidden_services=["times-square"])
+    env = env.model_copy(update={"title": "data.lsst.cloud"})
+    app = app_factory(env, all_envs={"idfprod": env})
+    table = _table(
+        parse(app, ".. rsp-data-table::\n   :scope: environments\n")
+    )
+    assert _headers(table) == ["Dataset", "data.lsst.cloud"]
+    assert app.warning.getvalue() == ""


### PR DESCRIPTION
## Summary

- Adds three dataset-aware Sphinx roles exposing Repertoire discovery's per-dataset service data to authors: `:rsp-data-url:`service dataset[/path]`` and its hyperlink twin `:rsp-data-link:` resolve a dataset's data-access service URL (`tap`, `sia`, `cutout`, `datalink`, `hips`) for the environment being built, and `:rsp-dataset-docs:` links a dataset's documentation site. Absent datasets/services, malformed targets, and missing docs URLs raise suppressible `rspdocs`-family warnings (fatal under `-W`), matching the existing `rsp-url`/`rsp-link` behavior.
- Adds a `.. rsp-data-table::` directive rendering availability matrices from discovery data at build time. The default `env` scope tabulates datasets × services for the current environment with each cell linking the live endpoint; `:scope: environments` tabulates datasets × dataset-serving environments for one `:service:`. Datasets with no user-facing services are omitted from default rows; the directive emits nothing when no rows remain (so dataset-less environments like `base` degrade cleanly); unknown `:services:`/`:datasets:`/`:service:` tokens warn.
- `conf.py` now fetches discovery data for the **full build roster** instead of just the target + primary environments (small per-env JSON, disk-cached), which the cross-environment scope requires, and `rsp_discovery_hash` now covers the roster so any environment's data change correctly triggers a rebuild of the table.
- The API aspect page (`api.primary.in.rst`) gains a "Data-access services by dataset" section driven by the table instead of hand-maintained content — on idfprod it renders dp02/dp1 with all five services and dp03 as TAP-only, and it tracks discovery automatically as datasets/services change.
- Documented in `docs/contributing/env-specific-docs.rst` (including the correction that per-dataset service names are *not* `rsp-only` condition tokens — gate on `api`/`tap` or environment names), the `env-specific-content` skill, and `AGENTS.md`. 30 new tests bring the suite to 102.

**Naming deviation from the issue:** the directive is `rsp-data-table`, not the sketched `rsp-env-table` — its default scope tabulates datasets × services (not environments), and the name matches the `rsp-data-*` role family. Flagging in case you prefer the original name.

## Validation steps

- [ ] Build `tox -e sphinx-idfprod` and check the API aspect page's "Data-access services by dataset" table (dp02 ✓✓✓✓✓, dp03 TAP-only, dp1 ✓✓✓✓✓; no `prompt` row)
- [ ] Build `tox -e sphinx-base` (a dataset-less environment) — green, with no table and no dangling section on the API page
- [ ] Build `tox -e sphinx-usdfprod` and confirm the table differs (dp1 without SIA/cutout; efd and live rows)
- [ ] Check the new sections of `docs/contributing/env-specific-docs.rst` render with the static role examples

## References

- Closes #90
- Jira: https://rubinobs.atlassian.net/browse/DM-55245