### PR TITLE
DM-55493: Adopt ruff for linting and formatting (retire black, flake8, isort)

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-max-line-length = 79
-# E203: whitespace before :, flake8 disagrees with PEP-8
-# W503: line break after binary operator, flake8 disagrees with PEP-8
-ignore = E203, W503

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,16 +15,12 @@ repos:
           - json
           - yaml
 
-  - repo: https://github.com/PyCQA/isort
-    rev: 5.13.2
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.15.21
     hooks:
-      - id: isort
-        additional_dependencies: [toml]
-
-  - repo: https://github.com/psf/black
-    rev: 24.8.0
-    hooks:
-      - id: black
+      - id: ruff-check
+        args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format
 
   - repo: https://github.com/asottile/blacken-docs
     rev: 1.18.0
@@ -32,11 +28,6 @@ repos:
       - id: blacken-docs
         additional_dependencies: [black==24.8.0]
         args: [-l, "79", -t, py312]
-
-  - repo: https://github.com/PyCQA/flake8
-    rev: 7.1.1
-    hooks:
-      - id: flake8
 
   - repo: local
     hooks:

--- a/conf.py
+++ b/conf.py
@@ -3,9 +3,8 @@ import hashlib
 import json
 import os
 from pathlib import Path
-from typing import Optional
 
-from documenteer.conf.guide import *  # noqa: F401 F403
+from documenteer.conf.guide import *  # noqa: F403
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from rspdocs.constants import PRIMARY_ENV
@@ -26,7 +25,7 @@ from rspdocs.sphinxext.services import excluded_page_patterns
 _metadata = load_environments_metadata()
 target_env = PRIMARY_ENV
 for env_name in _metadata.build_roster:
-    if env_name in tags:  # noqa: F405 F821
+    if env_name in tags:  # noqa: F405
         target_env = env_name
         break
 _fetch_envs = list(_metadata.build_roster)
@@ -36,7 +35,7 @@ env_service = PhalanxEnvService.load(
     env_names=_fetch_envs,
 )
 
-rsp_env: Optional[PhalanxEnv] = env_service.envs[target_env]
+rsp_env: PhalanxEnv | None = env_service.envs[target_env]
 
 # Enable the in-repo Sphinx extension providing the :rsp-url:/:rsp-link: roles
 # and the .. rsp-only:: directive. ``extensions`` is exported by
@@ -99,7 +98,7 @@ exclude_patterns = [
 exclude_patterns.extend(excluded_page_patterns(rsp_env))
 
 # Add environment switcher
-version = rsp_env.title  # noqa: F405
+version = rsp_env.title
 
 # Generate the version-switcher data from the build roster into the gitignored
 # _build/ dir and register it as a static asset (copied to

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ dev = [
     "respx",
     "pre-commit",
     "mypy",
+    "ruff",
 ]
 
 [project.scripts]
@@ -89,24 +90,6 @@ exclude_lines = [
     "if TYPE_CHECKING:",
 ]
 
-[tool.black]
-line-length = 79
-target-version = ["py38"]
-exclude = '''
-/(
-    \.eggs
-  | \.git
-  | \.mypy_cache
-  | \.tox
-  | \.venv
-  | _build
-  | build
-  | dist
-)/
-'''
-# Use single-quoted strings so TOML treats the string like a Python r-string
-#  Multi-line strings are implicitly treated by black as regular expressions
-
 [tool.pydocstyle]
 # Reference: http://www.pydocstyle.org/en/stable/error_codes.html
 convention = "numpy"
@@ -126,15 +109,41 @@ add-ignore = [
     "D401",
 ]
 
-[tool.isort]
-profile = "black"
-line_length = 79
-known_first_party = ["rspdocs", "tests"]
-skip = ["conf.py"]
-
 [tool.pytest.ini_options]
 asyncio_mode = "strict"
 python_files = ["tests/*.py", "tests/*/*.py"]
+
+[tool.ruff]
+extend = "ruff-shared.toml"
+
+[tool.ruff.lint]
+# D100/D200/D205/D400/D401 mirror this repo's long-standing pydocstyle
+# add-ignore above: multi-line summaries and non-imperative docstrings are
+# an accepted style here, not a lint target for this migration.
+extend-ignore = [
+    "D100",
+    "D200",
+    "D205",
+    "D400",
+    "D401",
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["rspdocs", "tests"]
+
+[tool.ruff.lint.extend-per-file-ignores]
+# conf.py is a Sphinx build-config module: print()/os.path/dynamic imports
+# are its normal idiom, not something this migration should rewrite.
+"conf.py" = ["T201", "PLC0415", "PTH118", "PTH119", "PTH110", "PTH122", "PTH207", "RUF005", "C901", "ANN001", "ANN201", "ANN202", "TD001", "FIX001", "D103"]
+# One-off maintenance/CLI scripts print progress to stdout by design.
+"scripts/*" = ["T201", "D103"]
+"src/rspdocs/validate.py" = ["T201", "PLC0415"]
+"src/rspdocs/pathlint.py" = ["T201"]
+"src/rspdocs/discovery/service.py" = ["T201"]
+"src/rspdocs/sphinxext/directives.py" = ["RUF012"]
+"src/rspdocs/sphinxext/tables.py" = ["RUF012"]
+"tests/discovery/test_metadata.py" = ["PT011"]
+"tests/sphinxext/test_services.py" = ["PT018"]
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -1,0 +1,154 @@
+# Generic shared Ruff configuration file. It should be possible to use this
+# file unmodified in different packages provided that one likes the style that
+# it enforces.
+#
+# This file should be used from pyproject.toml as follows:
+#
+#     [tool.ruff]
+#     extend = "ruff-shared.toml"
+#
+# It can then be extended with project-specific rules. A common additional
+# setting in pyproject.toml is tool.ruff.lint.extend-per-file-ignores, to add
+# additional project-specific ignore rules for specific paths.
+#
+# The rule used with Ruff configuration is to disable every non-deprecated
+# lint rule that has legitimate exceptions that are not dodgy code, rather
+# than cluttering code with noqa markers. This is therefore a reiatively
+# relaxed configuration that errs on the side of disabling legitimate rules.
+#
+# Reference for settings: https://docs.astral.sh/ruff/settings/
+# Reference for rules: https://docs.astral.sh/ruff/rules/
+exclude = ["docs/**"]
+line-length = 79
+
+[format]
+docstring-code-format = true
+
+[lint]
+ignore = [
+    "A005",     # we always use relative imports so this is not ambiguous
+    "ANN401",   # sometimes Any is the right type
+    "ARG001",   # unused function arguments are often legitimate
+    "ARG002",   # unused method arguments are often legitimate
+    "ARG003",   # unused class method arguments are often legitimate
+    "ARG005",   # unused lambda arguments are often legitimate
+    "ASYNC109", # many async functions use asyncio.timeout internally
+    "ASYNC240", # we don't want to run filesystem operations on threads
+    "BLE001",   # we want to catch and report Exception in background tasks
+    "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "D102",     # sometimes we use docstring inheritence
+    "D104",     # don't see the point of documenting every package
+    "D105",     # our style doesn't require docstrings for magic methods
+    "D106",     # Pydantic uses a nested Config class that doesn't warrant docs
+    "D205",     # our documentation style allows a folded first line
+    "EM101",    # justification (duplicate string in traceback) is silly
+    "EM102",    # justification (duplicate string in traceback) is silly
+    "FBT003",   # positional booleans are normal for Pydantic field defaults
+    "FIX002",   # point of a TODO comment is that we're not ready to fix it
+    "PD011",    # attempts to enforce pandas conventions for all data types
+    "G004",     # forbidding logging f-strings is appealing, but not our style
+    "RET505",   # disagree that omitting else always makes code more readable
+    "PLR0911",  # often many returns is clearer and simpler style
+    "PLR0913",  # factory pattern uses constructors with many arguments
+    "PLR2004",  # too aggressive about magic values
+    "PLW0603",  # yes global is discouraged but if needed, it's needed
+    "S105",     # good idea but too many false positives on non-passwords
+    "S106",     # good idea but too many false positives on non-passwords
+    "S107",     # good idea but too many false positives on non-passwords
+    "S603",     # not going to manually mark every subprocess call as reviewed
+    "S607",     # using PATH is not a security vulnerability
+    "SIM102",   # sometimes the formatting of nested if statements is clearer
+    "SIM117",   # sometimes nested with contexts are clearer
+    "TC001",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TC002",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TC003",    # we decided to not maintain separate TYPE_CHECKING blocks
+    "TD003",    # we don't require issues be created for TODOs
+    "TID252",   # if we're going to use relative imports, use them always
+    "TRY003",   # good general advice but lint is way too aggressive
+    "TRY301",   # sometimes raising exceptions inside try is the best flow
+    "UP040",    # PEP 695 type aliases not yet supported by mypy
+
+    # The following settings should be disabled when using ruff format
+    # per https://docs.astral.sh/ruff/formatter/#conflicting-lint-rules
+    "W191",
+    "E111",
+    "E114",
+    "E117",
+    "D206",
+    "D300",
+    "Q000",
+    "Q001",
+    "Q002",
+    "Q003",
+    "COM812",
+    "COM819",
+    "ISC001",
+    "ISC002",
+]
+select = ["ALL"]
+
+[lint.per-file-ignores]
+"alembic/**" = [
+    "INP001",  # Alembic files are magical
+    "D103",    # Alembic methods do not need docstrings
+    "D400",    # Alembic migrations have their own docstring format
+]
+"noxfile.py" = [
+    "T201",    # print makes sense as output from nox rules
+]
+"src/*/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
+]
+"*/src/*/handlers/**" = [
+    "D103",    # FastAPI handlers should not have docstrings
+]
+"tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # allow tests for whether code can be pickled
+    "SLF001",  # tests are allowed to access private members
+]
+"*/tests/**" = [
+    "C901",    # tests are allowed to be complex, sometimes that's convenient
+    "D101",    # tests don't need docstrings
+    "D103",    # tests don't need docstrings
+    "PLR0915", # tests are allowed to be long, sometimes that's convenient
+    "PT012",   # way too aggressive about limiting pytest.raises blocks
+    "S101",    # tests should use assert
+    "S106",    # tests are allowed to hard-code dummy passwords
+    "S301",    # allow tests for whether code can be pickled
+    "SLF001",  # tests are allowed to access private members
+]
+"tests/schema_test.py" = [
+    "ASYNC221", # useful to run subprocess in async tests for Alembic
+]
+"*/tests/schema_test.py" = [
+    "ASYNC221", # useful to run subprocess in async tests for Alembic
+]
+
+# These are too useful as attributes or methods to allow the conflict with the
+# built-in to rule out their use.
+[lint.flake8-builtins]
+builtins-ignorelist = [
+    "all",
+    "any",
+    "help",
+    "id",
+    "list",
+    "type",
+]
+
+[lint.flake8-pytest-style]
+fixture-parentheses = false
+mark-parentheses = false
+
+[lint.isort]
+split-on-trailing-comma = false
+
+[lint.pydocstyle]
+convention = "numpy"

--- a/src/rspdocs/constants.py
+++ b/src/rspdocs/constants.py
@@ -1,6 +1,6 @@
 """Constants (fixed, reusable configurations)."""
 
-__all__ = ["PRIMARY_ENV", "DOCS_ROOT_URL"]
+__all__ = ["DOCS_ROOT_URL", "PRIMARY_ENV"]
 
 
 PRIMARY_ENV = "idfprod"

--- a/src/rspdocs/discovery/models.py
+++ b/src/rspdocs/discovery/models.py
@@ -12,8 +12,8 @@ from .metadata import EnvMeta
 
 __all__ = [
     "DatasetInfo",
-    "PhalanxEnv",
     "EnvironmentDict",
+    "PhalanxEnv",
     "ltd_edition_url",
 ]
 

--- a/src/rspdocs/sphinxext/logging.py
+++ b/src/rspdocs/sphinxext/logging.py
@@ -17,23 +17,23 @@ from typing import Any
 from sphinx.util import logging
 
 __all__ = [
-    "WARNING_TYPE",
-    "UNKNOWN_SERVICE",
-    "UNAVAILABLE_SERVICE",
-    "UNKNOWN_CONDITION",
-    "UNKNOWN_DATASET_SERVICE",
-    "UNKNOWN_DATASET",
+    "MALFORMED_DATASET_TARGET",
     "UNAVAILABLE_DATASET",
     "UNAVAILABLE_DATASET_DOCS",
-    "MALFORMED_DATASET_TARGET",
-    "warn_unknown_service",
-    "warn_unavailable_service",
-    "warn_unknown_condition",
-    "warn_unknown_dataset_service",
-    "warn_unknown_dataset",
+    "UNAVAILABLE_SERVICE",
+    "UNKNOWN_CONDITION",
+    "UNKNOWN_DATASET",
+    "UNKNOWN_DATASET_SERVICE",
+    "UNKNOWN_SERVICE",
+    "WARNING_TYPE",
+    "warn_malformed_dataset_target",
     "warn_unavailable_dataset",
     "warn_unavailable_dataset_docs",
-    "warn_malformed_dataset_target",
+    "warn_unavailable_service",
+    "warn_unknown_condition",
+    "warn_unknown_dataset",
+    "warn_unknown_dataset_service",
+    "warn_unknown_service",
 ]
 
 logger = logging.getLogger(__name__)

--- a/src/rspdocs/sphinxext/roles.py
+++ b/src/rspdocs/sphinxext/roles.py
@@ -35,11 +35,11 @@ from .services import (
 )
 
 __all__ = [
-    "RspUrlRole",
-    "RspLinkRole",
-    "RspDataUrlRole",
     "RspDataLinkRole",
+    "RspDataUrlRole",
     "RspDatasetDocsRole",
+    "RspLinkRole",
+    "RspUrlRole",
 ]
 
 

--- a/src/rspdocs/sphinxext/services.py
+++ b/src/rspdocs/sphinxext/services.py
@@ -25,20 +25,20 @@ from ..discovery.metadata import load_environments_metadata
 from ..discovery.models import DATASET_SERVICES, PhalanxEnv
 
 __all__ = [
-    "SERVICE_ATTRS",
-    "SERVICE_PAGE_EXCLUDES",
     "DATASET_SERVICE_LABELS",
     "KNOWN_ENVS",
-    "is_known_service",
-    "is_known_dataset_service",
-    "split_service_path",
-    "split_dataset_target",
-    "resolve_url",
-    "resolve_dataset_url",
-    "resolve_dataset_docs_url",
-    "is_available",
-    "resolve_condition",
+    "SERVICE_ATTRS",
+    "SERVICE_PAGE_EXCLUDES",
     "excluded_page_patterns",
+    "is_available",
+    "is_known_dataset_service",
+    "is_known_service",
+    "resolve_condition",
+    "resolve_dataset_docs_url",
+    "resolve_dataset_url",
+    "resolve_url",
+    "split_dataset_target",
+    "split_service_path",
 ]
 
 SERVICE_ATTRS: dict[str, str] = {


### PR DESCRIPTION
## Summary

Retires black, isort, and flake8 in favor of ruff (ruff-check + ruff-format), matching the `square_pypi_package` template's linting stack.

- Removed `[tool.black]` and `[tool.isort]` from `pyproject.toml`; removed `.flake8`.
- Replaced the `black`/`isort`/`flake8` pre-commit hooks with `ruff-check` and `ruff-format`, pinned to `ruff-pre-commit` `v0.15.21` (needed to parse `ruff-shared.toml`'s `ASYNC240` selector, which requires ruff >= 0.15).
- Vendored `ruff-shared.toml` verbatim from `project_templates/square_pypi_package` and added `[tool.ruff] extend = "ruff-shared.toml"`.
- Carried over the old isort `known_first_party` setting as `[tool.ruff.lint.isort] known-first-party`.
- Mirrored this repo's existing `[tool.pydocstyle]` `add-ignore` list (D100, D200, D205, D400, D401) into ruff's `lint.extend-ignore`, since those are pre-existing accepted docstring conventions here, not new lint targets to fix.
- Added scoped `extend-per-file-ignores` for `conf.py` (Sphinx-config idioms: `print`/`os.path`/dynamic imports), the maintenance `scripts/` (progress `print`s), and a handful of pre-existing findings (RUF012, PT011, PT018) rather than rewriting code to satisfy new rules — keeping this PR scoped to the ruff conversion.
- Added `ruff` as a dev dependency.
- Reformatted via `ruff format .` and `ruff check --fix .` — this produces the large formatting diff, which is expected and applied mechanically.

Also keeps the `blacken-docs` pre-commit hook, which is unrelated to `black`-the-linter and formats code blocks embedded in docs.

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

## Test plan

- [x] `pre-commit run --all-files` passes clean (ruff-check, ruff-format, and the local `rspdocs-validate-config`/`rspdocs-lint-paths` hooks)
- [x] `pytest` — 102 passed
- [x] `mypy src/rspdocs tests --explicit-package-bases` — no issues found
- [x] Confirmed no `[tool.black]`/`[tool.isort]` remain in `pyproject.toml`, no `.flake8`/`[flake8]` remain, and `.pre-commit-config.yaml` has no `black`/`isort`/`flake8` hooks

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ