### PR TITLE
DM-55493: Refresh vendored ruff-shared.toml for ruff 0.16 CPY001

### DIFF
--- a/ruff-shared.toml
+++ b/ruff-shared.toml
@@ -36,6 +36,7 @@ ignore = [
     "ASYNC240", # we don't want to run filesystem operations on threads
     "BLE001",   # we want to catch and report Exception in background tasks
     "C414",     # nested sorted is how you sort by multiple keys with reverse
+    "CPY001",   # No, every single file doesn't need its own copyright notice
     "D102",     # sometimes we use docstring inheritence
     "D104",     # don't see the point of documenting every package
     "D105",     # our style doesn't require docstrings for magic methods


### PR DESCRIPTION
## Summary

- Refreshes the vendored `ruff-shared.toml` from the `square_pypi_package` lsst/templates kind template, picking up the single-line addition from lsst/templates@dd8e4b26: adds `CPY001` (missing-copyright-notice) to the `[lint] ignore` list.
- This repo's ruff config belongs to an embedded package (docs-site kind `lsst`), so it follows the `square_pypi_package` template, not `fastapi_safir_app`.
- Verbatim overwrite; no other repo-specific ruff settings were changed. `pyproject.toml` `[tool.ruff]` keys (extend-ignore, known-first-party, per-file-ignores) are untouched — no redundant keys found to prune.
- `ruff check .` and `ruff format --check .` pass locally with the repo's pinned pre-commit rev (0.15.21).

Jira: [DM-55493](https://rubinobs.atlassian.net/browse/DM-55493)

## Test plan

- [x] `ruff check .` — all checks passed
- [x] `ruff format --check .` — all files already formatted
- [x] Diffed vendored file against upstream template before/after: only the expected `CPY001` ignore line added

[DM-55493]: https://rubinobs.atlassian.net/browse/DM-55493?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ