### PR TITLE
Remove doc_path for 'Edit on GitHub' link

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -123,10 +123,6 @@ html_theme_options["navbar_center"] = [  # noqa: F405
 ]
 html_theme_options["navbar_align"] = "left"  # noqa: F405
 
-# Update doc_path for the "Edit on GitHub" link. The DocumenteerGuide preset
-# doesn't work here because docs/ doesn't contain the Sphinx conf.py.
-html_context["doc_path"] = "docs"  # noqa: F405
-
 # Delete any objects that needn't be pickled with the Sphinx configuration
 del _config_template_loader
 del _jinja_env


### PR DESCRIPTION
Removed unnecessary doc_path setting for GitHub link, Documenteer 2.4.1 now provides this functionality.